### PR TITLE
feat: Add `context.resources` to types

### DIFF
--- a/src/definers.ts
+++ b/src/definers.ts
@@ -16,8 +16,6 @@ export function documentEventHandler<IData = any>(handler: DocumentEventHandler<
  * Defines a "scheduled event" function handler.
  * Returns the handler function as-is, only providing the types and doing basic validation.
  *
- * @alpha
- * @hidden
  * @param handler - The event handler function to use.
  * @returns The handler function, unmodified.
  */

--- a/src/types.ts
+++ b/src/types.ts
@@ -39,6 +39,8 @@ export interface FunctionContext {
     projectId: string
     token: string
   }
+  /** Resource interface that allows access to Blueprint Resources */
+  resources: ResourcesApi
 }
 
 /**
@@ -74,6 +76,8 @@ export interface ScheduledFunctionContext {
     projectId?: string
     token?: string
   }
+  /** Resource interface that allows access to Blueprint Resources */
+  resources: ResourcesApi
 }
 
 /**
@@ -162,3 +166,33 @@ export type SyncTagInvalidateEventHandler = (envelope: {
   event: SyncTagInvalidateEvent
   done: SyncTagInvalidateCallback
 }) => void | Promise<void>
+
+/**
+ * An interface to describe resources found in a Blueprint
+ */
+export interface BlueprintResource {
+  id: string
+  name: string
+  type: string
+}
+
+interface ResourcesApiCore {
+  /** Cross-type lookup by name: `context.resources('my-proj')`. */
+  (name: string): BlueprintResource | undefined
+  /** Flat array of every resource across types. */
+  all(): BlueprintResource[]
+  /** Iterate every resource: `for (const r of context.resources)`. */
+  [Symbol.iterator](): IterableIterator<BlueprintResource>
+}
+
+/** Per-type lookup, e.g. `context.resources.project('my-proj')`. Unknown types yield a function that
+returns `undefined`. */
+type ResourcesApiByType = Record<string, (name: string) => BlueprintResource | undefined>
+
+/**
+ * Callable ResourcesApi
+ * Invoke directly for a cross-type lookup (`resources('my-proj')`)
+ * Use `.<type>(name)` for a per-type lookup (`resources.project('my-proj')`)
+ * `.all()` for the flat list, or iterate.
+ */
+export type ResourcesApi = ResourcesApiCore & ResourcesApiByType

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,7 +1,5 @@
 /**
  * The context object passed to the function handler.
- *
- * @beta
  */
 export interface FunctionContext {
   /** The resource type of the event source; resource type that invoked the function. */
@@ -31,7 +29,6 @@ export interface FunctionContext {
    *   ...context.clientOptions,
    * })
    * ```
-   * @beta
    */
   clientOptions: {
     apiHost?: string
@@ -45,8 +42,6 @@ export interface FunctionContext {
 
 /**
  * The context object passed to the schedule function handler.
- *
- * @beta
  */
 export interface ScheduledFunctionContext {
   /**
@@ -68,7 +63,6 @@ export interface ScheduledFunctionContext {
    *   ...context.clientOptions,
    * })
    * ```
-   * @beta
    */
   clientOptions?: {
     apiHost?: string
@@ -83,30 +77,22 @@ export interface ScheduledFunctionContext {
 /**
  * The event object received by the function handler in the case of a document event,
  * such as a publish, unpublish, delete or mutation event and similar.
- *
- * @beta
  */
 export interface DocumentEvent<IData = any> {
   /**
    * The data delivered to the function. This is the result of applying any configured
    * GROQ-projection to the changed document. If no projection is configured, this is
    * the document itself.
-   *
-   * @beta
    */
   data: IData
 }
 
 /**
  * The event object received by the function handler in the case of a sync-tag-invalidate event.
- *
- * @beta
  */
 export interface SyncTagInvalidateEvent {
   /**
    * The sync tags for use with cache invalidation and notifying the callback endpoint once tags are invalidated.
-   *
-   * @beta
    */
   data: {
     /** Array of sync tags to be invalidated. */
@@ -116,29 +102,21 @@ export interface SyncTagInvalidateEvent {
 
 /**
  * A function handler for a document event.
- *
- * @beta
  */
 export type DocumentEventHandler<IData = any> = (envelope: {context: FunctionContext; event: DocumentEvent<IData>}) => void | Promise<void>
 
 /**
  * A function handler for a schedule event.
- *
- * @beta
  */
 export type ScheduledEventHandler = (envelope: {context: ScheduledFunctionContext}) => void | Promise<void>
 
 /**
  * A callback function to invoke once a sync-tag-invalidate event has been processed. Signals to Sanity that sync tag invalidation has completed.
- *
- * @beta
  */
 export type SyncTagInvalidateCallback = (syncTags: string[]) => Promise<Response>
 
 /**
  * The context object passed to the sync tag invalidate event handler.
- *
- * @beta
  */
 export interface SyncTagInvalidateContext extends Omit<FunctionContext, 'clientOptions'> {
   /**
@@ -158,8 +136,6 @@ export interface SyncTagInvalidateContext extends Omit<FunctionContext, 'clientO
 }
 /**
  * A function handler for a sync-tag-invalidate event.
- *
- * @beta
  */
 export type SyncTagInvalidateEventHandler = (envelope: {
   context: SyncTagInvalidateContext
@@ -175,24 +151,17 @@ export interface BlueprintResource {
   name: string
   type: string
 }
-
-interface ResourcesApiCore {
+export interface ResourcesApi {
   /** Cross-type lookup by name: `context.resources('my-proj')`. */
   (name: string): BlueprintResource | undefined
   /** Flat array of every resource across types. */
   all(): BlueprintResource[]
   /** Iterate every resource: `for (const r of context.resources)`. */
   [Symbol.iterator](): IterableIterator<BlueprintResource>
+  /** Type specific lookup by name: `context.cors('my-cors')` */
+  cors(name: string): BlueprintResource | undefined
+  dataset(name: string): BlueprintResource | undefined
+  project(name: string): BlueprintResource | undefined
+  role(name: string): BlueprintResource | undefined
+  webhook(name: string): BlueprintResource | undefined
 }
-
-/** Per-type lookup, e.g. `context.resources.project('my-proj')`. Unknown types yield a function that
-returns `undefined`. */
-type ResourcesApiByType = Record<string, (name: string) => BlueprintResource | undefined>
-
-/**
- * Callable ResourcesApi
- * Invoke directly for a cross-type lookup (`resources('my-proj')`)
- * Use `.<type>(name)` for a per-type lookup (`resources.project('my-proj')`)
- * `.all()` for the flat list, or iterate.
- */
-export type ResourcesApi = ResourcesApiCore & ResourcesApiByType

--- a/src/types.ts
+++ b/src/types.ts
@@ -161,6 +161,7 @@ export interface ResourcesApi {
   /** Type specific lookup by name: `context.cors('my-cors')` */
   cors(name: string): BlueprintResource | undefined
   dataset(name: string): BlueprintResource | undefined
+  function(name: string): BlueprintResource | undefined
   project(name: string): BlueprintResource | undefined
   role(name: string): BlueprintResource | undefined
   webhook(name: string): BlueprintResource | undefined

--- a/test/definers.test-d.ts
+++ b/test/definers.test-d.ts
@@ -1,9 +1,11 @@
 import {assertType, describe, expect, expectTypeOf, test} from 'vitest'
 import {
+  type BlueprintResource,
   type DocumentEvent,
   type DocumentEventHandler,
   documentEventHandler,
   type FunctionContext,
+  type ResourcesApi,
   type ScheduledEventHandler,
   type ScheduledFunctionContext,
   type SyncTagInvalidateCallback,
@@ -14,6 +16,24 @@ import {
   syncTagInvalidateEventHandler,
 } from '../src'
 
+const mockResourcesApi = (resources: BlueprintResource[] = []): ResourcesApi => {
+  const findByName = (name: string) => resources.find((r) => r.name === name)
+  const all = () => resources
+
+  return new Proxy(findByName, {
+    get: (_target, prop) => {
+      if (prop === 'all') return all
+      if (prop === Symbol.iterator) {
+        return function* () {
+          yield* all()
+        }
+      }
+      if (typeof prop !== 'string' || prop === 'then') return undefined
+      return (name: string) => resources.find((r) => r.type === prop && r.name === name)
+    },
+  }) as unknown as ResourcesApi
+}
+
 describe('documentEventHandler', () => {
   const context: FunctionContext = {
     eventResourceId: 'abc123.xyz789',
@@ -21,6 +41,7 @@ describe('documentEventHandler', () => {
     functionResourceId: 'abc123',
     functionResourceType: 'project',
     clientOptions: {projectId: 'abc123', dataset: 'xyz789', token: 'sk_some-token'},
+    resources: mockResourcesApi(),
   }
 
   const event: DocumentEvent = {
@@ -70,6 +91,7 @@ describe('documentEventHandler', () => {
 describe('scheduledEventHandler', () => {
   const context: ScheduledFunctionContext = {
     local: true,
+    resources: mockResourcesApi(),
   }
 
   test('has correct type signature', () => {
@@ -107,6 +129,7 @@ describe('syncTagInvalidateEventHandler', () => {
     functionResourceId: 'abc123',
     functionResourceType: 'project',
     clientOptions: {apiHost: 'api.sanity.io', projectId: 'abc123', dataset: 'xyz789'},
+    resources: mockResourcesApi(),
   }
 
   const event: SyncTagInvalidateEvent = {

--- a/test/resources.test-d.ts
+++ b/test/resources.test-d.ts
@@ -29,6 +29,7 @@ describe('ResourcesApi', () => {
 
     expectTypeOf<ResourcesApi['cors']>().toEqualTypeOf<PerTypeLookup>()
     expectTypeOf<ResourcesApi['dataset']>().toEqualTypeOf<PerTypeLookup>()
+    expectTypeOf<ResourcesApi['function']>().toEqualTypeOf<PerTypeLookup>()
     expectTypeOf<ResourcesApi['project']>().toEqualTypeOf<PerTypeLookup>()
     expectTypeOf<ResourcesApi['role']>().toEqualTypeOf<PerTypeLookup>()
     expectTypeOf<ResourcesApi['webhook']>().toEqualTypeOf<PerTypeLookup>()
@@ -36,6 +37,7 @@ describe('ResourcesApi', () => {
     const resources = {} as ResourcesApi
     expectTypeOf(resources.cors('my-cors')).toEqualTypeOf<BlueprintResource | undefined>()
     expectTypeOf(resources.dataset('my-dataset')).toEqualTypeOf<BlueprintResource | undefined>()
+    expectTypeOf(resources.function('my-function')).toEqualTypeOf<BlueprintResource | undefined>()
     expectTypeOf(resources.project('my-proj')).toEqualTypeOf<BlueprintResource | undefined>()
     expectTypeOf(resources.role('my-role')).toEqualTypeOf<BlueprintResource | undefined>()
     expectTypeOf(resources.webhook('my-webhook')).toEqualTypeOf<BlueprintResource | undefined>()
@@ -43,8 +45,8 @@ describe('ResourcesApi', () => {
 
   test('unknown resource types are not part of the API', () => {
     const resources = {} as ResourcesApi
-    // @ts-expect-error `function` is not a known resource type
-    assertType(resources.function('my-fn'))
+    // @ts-expect-error `studio` is not a known resource type
+    assertType(resources.studio('my-studio'))
   })
 
   test('rejects non-string arguments to the callable form', () => {

--- a/test/resources.test-d.ts
+++ b/test/resources.test-d.ts
@@ -1,5 +1,5 @@
-import { assertType, describe, expectTypeOf, test } from 'vitest'
-import type { BlueprintResource, ResourcesApi } from '../src'
+import {assertType, describe, expectTypeOf, test} from 'vitest'
+import type {BlueprintResource, ResourcesApi} from '../src'
 
 describe('ResourcesApi', () => {
   test('is callable for cross-type lookup by name', () => {
@@ -24,13 +24,27 @@ describe('ResourcesApi', () => {
     }
   })
 
-  test('per-type lookup returns BlueprintResource | undefined', () => {
-    expectTypeOf<ResourcesApi['project']>().toEqualTypeOf<(name: string) => BlueprintResource | undefined>()
-    expectTypeOf<ResourcesApi['dataset']>().toEqualTypeOf<(name: string) => BlueprintResource | undefined>()
+  test('per-type lookup returns BlueprintResource | undefined for every known type', () => {
+    type PerTypeLookup = (name: string) => BlueprintResource | undefined
+
+    expectTypeOf<ResourcesApi['cors']>().toEqualTypeOf<PerTypeLookup>()
+    expectTypeOf<ResourcesApi['dataset']>().toEqualTypeOf<PerTypeLookup>()
+    expectTypeOf<ResourcesApi['project']>().toEqualTypeOf<PerTypeLookup>()
+    expectTypeOf<ResourcesApi['role']>().toEqualTypeOf<PerTypeLookup>()
+    expectTypeOf<ResourcesApi['webhook']>().toEqualTypeOf<PerTypeLookup>()
 
     const resources = {} as ResourcesApi
-    expectTypeOf(resources.project('my-proj')).toEqualTypeOf<BlueprintResource | undefined>()
+    expectTypeOf(resources.cors('my-cors')).toEqualTypeOf<BlueprintResource | undefined>()
     expectTypeOf(resources.dataset('my-dataset')).toEqualTypeOf<BlueprintResource | undefined>()
+    expectTypeOf(resources.project('my-proj')).toEqualTypeOf<BlueprintResource | undefined>()
+    expectTypeOf(resources.role('my-role')).toEqualTypeOf<BlueprintResource | undefined>()
+    expectTypeOf(resources.webhook('my-webhook')).toEqualTypeOf<BlueprintResource | undefined>()
+  })
+
+  test('unknown resource types are not part of the API', () => {
+    const resources = {} as ResourcesApi
+    // @ts-expect-error `function` is not a known resource type
+    assertType(resources.function('my-fn'))
   })
 
   test('rejects non-string arguments to the callable form', () => {

--- a/test/resources.test-d.ts
+++ b/test/resources.test-d.ts
@@ -1,0 +1,43 @@
+import { assertType, describe, expectTypeOf, test } from 'vitest'
+import type { BlueprintResource, ResourcesApi } from '../src'
+
+describe('ResourcesApi', () => {
+  test('is callable for cross-type lookup by name', () => {
+    expectTypeOf<ResourcesApi>().toBeCallableWith('my-proj')
+    expectTypeOf<ResourcesApi>().returns.toEqualTypeOf<BlueprintResource | undefined>()
+  })
+
+  test('.all() returns a flat array of resources', () => {
+    expectTypeOf<ResourcesApi['all']>().toBeFunction()
+    expectTypeOf<ResourcesApi['all']>().returns.toEqualTypeOf<BlueprintResource[]>()
+  })
+
+  test('is iterable as Iterable<BlueprintResource>', () => {
+    expectTypeOf<ResourcesApi>().toExtend<Iterable<BlueprintResource>>()
+
+    const resources = {} as ResourcesApi
+    const spread = [...resources]
+    expectTypeOf(spread).toEqualTypeOf<BlueprintResource[]>()
+
+    for (const resource of resources) {
+      expectTypeOf(resource).toEqualTypeOf<BlueprintResource>()
+    }
+  })
+
+  test('per-type lookup returns BlueprintResource | undefined', () => {
+    expectTypeOf<ResourcesApi['project']>().toEqualTypeOf<(name: string) => BlueprintResource | undefined>()
+    expectTypeOf<ResourcesApi['dataset']>().toEqualTypeOf<(name: string) => BlueprintResource | undefined>()
+
+    const resources = {} as ResourcesApi
+    expectTypeOf(resources.project('my-proj')).toEqualTypeOf<BlueprintResource | undefined>()
+    expectTypeOf(resources.dataset('my-dataset')).toEqualTypeOf<BlueprintResource | undefined>()
+  })
+
+  test('rejects non-string arguments to the callable form', () => {
+    const resources = {} as ResourcesApi
+    // @ts-expect-error name must be a string
+    assertType(resources(123))
+    // @ts-expect-error per-type name must be a string
+    assertType(resources.project(123))
+  })
+})


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

This adds the `ResourceAPI` interface to the `context.resources` property.

This PR should be reviewed but not merged until we have pushed all the changes to the internal services to prod.

See [RUN-1366](https://linear.app/sanity/issue/RUN-1366/add-contextresources-to-sanityfunctions)

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

- I removed all `@alpha` and `@beta` tags as we are GA now right?
- Eagle-eyed reviewers may notice that the `ResourceAPI` interface in `src/types.ts` has named functions to look up datasets, projects, etc. instead of using a Proxy like in `sanity-function-wrapper`. I had to do this since TypeScript in strict mode would complain about `context.resources.dataset('my-dataset')` and instead insist that it be written `context.resources['dataset']('my-dataset')` which made me throw up a little bit just typing it.

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

Added new automated testing