### PR TITLE
feat: add invoke method

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,20 @@
       "name": "@sanity/functions",
       "version": "1.3.1",
       "license": "MIT",
+      "dependencies": {
+        "@aws-lite/client": "^0.23.6",
+        "@aws-lite/dynamodb": "^0.3.9",
+        "@aws-lite/dynamodb-types": "^0.3.12",
+        "@aws-lite/lambda": "^0.1.5",
+        "@aws-lite/sns": "^0.0.8",
+        "@aws-lite/sns-types": "^0.0.11",
+        "@aws-lite/sqs": "^0.2.4"
+      },
       "devDependencies": {
+        "@aws-lite/lambda-types": "^0.1.6",
+        "@aws-lite/sqs-types": "^0.2.7",
         "@biomejs/biome": "2.3.12",
-        "@types/node": "^20",
+        "@types/node": "^20.19.39",
         "@vitest/coverage-v8": "^4.0.18",
         "rimraf": "^6.1.2",
         "typedoc": "^0.28.16",
@@ -19,6 +30,1045 @@
       },
       "engines": {
         "node": ">=20.19"
+      }
+    },
+    "node_modules/@aws-crypto/crc32": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-5.2.0.tgz",
+      "integrity": "sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
+      "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-js": "^5.2.0",
+        "@aws-crypto/supports-web-crypto": "^5.2.0",
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-js": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
+      "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/supports-web-crypto": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
+      "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/util": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
+      "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.222.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/util/node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/util/node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/util/node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-lite/client": {
+      "version": "0.23.6",
+      "resolved": "https://registry.npmjs.org/@aws-lite/client/-/client-0.23.6.tgz",
+      "integrity": "sha512-37oDevQKNCv5GpZ+4J7awO7B4BfHMisek6Z3ofEE9XOmxMrRrLnBBH8/Qf/ByR/qpygy293WW4ekVNiR1MUu+Q==",
+      "license": "Apache-2.0",
+      "workspaces": [
+        "plugins/acm",
+        "plugins/acm/types",
+        "plugins/apigateway",
+        "plugins/apigateway/types",
+        "plugins/apigatewaymanagementapi",
+        "plugins/apigatewaymanagementapi/types",
+        "plugins/apigatewayv2",
+        "plugins/apigatewayv2/types",
+        "plugins/cloudformation",
+        "plugins/cloudformation/types",
+        "plugins/cloudfront",
+        "plugins/cloudfront/types",
+        "plugins/cloudwatch-logs",
+        "plugins/cloudwatch-logs/types",
+        "plugins/dynamodb",
+        "plugins/dynamodb/types",
+        "plugins/iam",
+        "plugins/iam/types",
+        "plugins/lambda",
+        "plugins/lambda/types",
+        "plugins/organizations",
+        "plugins/organizations/types",
+        "plugins/rds-data",
+        "plugins/rds-data/types",
+        "plugins/route53",
+        "plugins/route53/types",
+        "plugins/s3",
+        "plugins/s3/types",
+        "plugins/sns",
+        "plugins/sns/types",
+        "plugins/sqs",
+        "plugins/sqs/types",
+        "plugins/ssm",
+        "plugins/ssm/types",
+        "plugins/sts",
+        "plugins/sts/types"
+      ],
+      "dependencies": {
+        "aws4": "^1.13.2"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@aws-lite/dynamodb": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@aws-lite/dynamodb/-/dynamodb-0.3.9.tgz",
+      "integrity": "sha512-jrMAWwxoAMVJ3z0/mI/GzPM5AfGmH+xzTpNIbjg3+2WdYJRqvIf8025XJdCDtS9/4x8zogdchEp3ZelXnwYyqw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@aws-lite/dynamodb-types": {
+      "version": "0.3.12",
+      "resolved": "https://registry.npmjs.org/@aws-lite/dynamodb-types/-/dynamodb-types-0.3.12.tgz",
+      "integrity": "sha512-CIqmmIDbf2PBLdZ9NaGY0mYIkqGO3yYLZEIWyaiSJweg8Ka1dk3bn4/LktJ0pjKgKyciMqCB7FdkLmeqLCLw6w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/client-dynamodb": "3"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@aws-lite/lambda": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/@aws-lite/lambda/-/lambda-0.1.5.tgz",
+      "integrity": "sha512-Sa6AxBQwzqGsUr2ifxcpAvFlTkoDwIQIYgcEFVQ+0qKeV9ci+ggsOOSRGBxrGEdRsnQxUsQ2x0ES/29c8crzQw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@aws-lite/lambda-types": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@aws-lite/lambda-types/-/lambda-types-0.1.6.tgz",
+      "integrity": "sha512-NB5Tarj2WpYZtDg/nrkT9lQtjy5tfzPzQDLY3TL3j/TFqo/q5WZNy9LB0MHOBqffScMSnuV4ybBerJ0NfG67jA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/client-lambda": "3"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@aws-lite/sns": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/@aws-lite/sns/-/sns-0.0.8.tgz",
+      "integrity": "sha512-MIzHe66kLNyzPFY/DX30uN7DlVQsnBiHPYbq/7syNWuoYSG8bkWuUX2CVIuSL7Ji5jaLpQ4lf8/VQ+SiAeoIZA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@aws-lite/sns-types": {
+      "version": "0.0.11",
+      "resolved": "https://registry.npmjs.org/@aws-lite/sns-types/-/sns-types-0.0.11.tgz",
+      "integrity": "sha512-RYa+2dr8Gsq92fa6e4K72HQ84hNONftPnN21Jpq3lkTpMozIS7aJdOSphDc5UcAKt5ZrYzjfRCcHM7OOZLua9g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/client-sns": "3"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@aws-lite/sqs": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@aws-lite/sqs/-/sqs-0.2.4.tgz",
+      "integrity": "sha512-a1M3HDdkNE/xJfASlfisAaZ8XF6FpvoJbJsH/gr6pogEFWgNQyvmPVNRElnDY7JW3ee82sEOkMukYRdAbjytNQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@aws-lite/sqs-types": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/@aws-lite/sqs-types/-/sqs-types-0.2.7.tgz",
+      "integrity": "sha512-OHJWRUps3eq4msTslP7X9apUNRqq2N4sNtnm3IM1l15ax4KtM7ib4vxZQ2YRpX7K8BjabdlxQobPyINoNnATjw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/client-sqs": "3"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb": {
+      "version": "3.1044.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-dynamodb/-/client-dynamodb-3.1044.0.tgz",
+      "integrity": "sha512-E9dZeAbyWC1YRAjdeQ7i1aK8635cQSpX4m0cUAlySiQRLux7NZa89BER07LU5OLi6ObnTi0FE7Vy0WbICUotjw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.974.8",
+        "@aws-sdk/credential-provider-node": "^3.972.39",
+        "@aws-sdk/dynamodb-codec": "^3.973.8",
+        "@aws-sdk/middleware-endpoint-discovery": "^3.972.11",
+        "@aws-sdk/middleware-host-header": "^3.972.10",
+        "@aws-sdk/middleware-logger": "^3.972.10",
+        "@aws-sdk/middleware-recursion-detection": "^3.972.11",
+        "@aws-sdk/middleware-user-agent": "^3.972.38",
+        "@aws-sdk/region-config-resolver": "^3.972.13",
+        "@aws-sdk/types": "^3.973.8",
+        "@aws-sdk/util-endpoints": "^3.996.8",
+        "@aws-sdk/util-user-agent-browser": "^3.972.10",
+        "@aws-sdk/util-user-agent-node": "^3.973.24",
+        "@smithy/config-resolver": "^4.4.17",
+        "@smithy/core": "^3.23.17",
+        "@smithy/fetch-http-handler": "^5.3.17",
+        "@smithy/hash-node": "^4.2.14",
+        "@smithy/invalid-dependency": "^4.2.14",
+        "@smithy/middleware-content-length": "^4.2.14",
+        "@smithy/middleware-endpoint": "^4.4.32",
+        "@smithy/middleware-retry": "^4.5.7",
+        "@smithy/middleware-serde": "^4.2.20",
+        "@smithy/middleware-stack": "^4.2.14",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/node-http-handler": "^4.6.1",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/smithy-client": "^4.12.13",
+        "@smithy/types": "^4.14.1",
+        "@smithy/url-parser": "^4.2.14",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-body-length-browser": "^4.2.2",
+        "@smithy/util-body-length-node": "^4.2.3",
+        "@smithy/util-defaults-mode-browser": "^4.3.49",
+        "@smithy/util-defaults-mode-node": "^4.2.54",
+        "@smithy/util-endpoints": "^3.4.2",
+        "@smithy/util-middleware": "^4.2.14",
+        "@smithy/util-retry": "^4.3.6",
+        "@smithy/util-utf8": "^4.2.2",
+        "@smithy/util-waiter": "^4.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-lambda": {
+      "version": "3.1045.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-lambda/-/client-lambda-3.1045.0.tgz",
+      "integrity": "sha512-9EDPinh03XanJQssTBdTY+9E7PkyQ0NLLJiaOAM71/g4DI+0OZboGqhX7KKizwUGqKkj0paKEAwgWaMLgEkQFQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.974.8",
+        "@aws-sdk/credential-provider-node": "^3.972.39",
+        "@aws-sdk/middleware-host-header": "^3.972.10",
+        "@aws-sdk/middleware-logger": "^3.972.10",
+        "@aws-sdk/middleware-recursion-detection": "^3.972.11",
+        "@aws-sdk/middleware-user-agent": "^3.972.38",
+        "@aws-sdk/region-config-resolver": "^3.972.13",
+        "@aws-sdk/types": "^3.973.8",
+        "@aws-sdk/util-endpoints": "^3.996.8",
+        "@aws-sdk/util-user-agent-browser": "^3.972.10",
+        "@aws-sdk/util-user-agent-node": "^3.973.24",
+        "@smithy/config-resolver": "^4.4.17",
+        "@smithy/core": "^3.23.17",
+        "@smithy/eventstream-serde-browser": "^4.2.14",
+        "@smithy/eventstream-serde-config-resolver": "^4.3.14",
+        "@smithy/eventstream-serde-node": "^4.2.14",
+        "@smithy/fetch-http-handler": "^5.3.17",
+        "@smithy/hash-node": "^4.2.14",
+        "@smithy/invalid-dependency": "^4.2.14",
+        "@smithy/middleware-content-length": "^4.2.14",
+        "@smithy/middleware-endpoint": "^4.4.32",
+        "@smithy/middleware-retry": "^4.5.7",
+        "@smithy/middleware-serde": "^4.2.20",
+        "@smithy/middleware-stack": "^4.2.14",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/node-http-handler": "^4.6.1",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/smithy-client": "^4.12.13",
+        "@smithy/types": "^4.14.1",
+        "@smithy/url-parser": "^4.2.14",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-body-length-browser": "^4.2.2",
+        "@smithy/util-body-length-node": "^4.2.3",
+        "@smithy/util-defaults-mode-browser": "^4.3.49",
+        "@smithy/util-defaults-mode-node": "^4.2.54",
+        "@smithy/util-endpoints": "^3.4.2",
+        "@smithy/util-middleware": "^4.2.14",
+        "@smithy/util-retry": "^4.3.6",
+        "@smithy/util-stream": "^4.5.25",
+        "@smithy/util-utf8": "^4.2.2",
+        "@smithy/util-waiter": "^4.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sns": {
+      "version": "3.1044.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sns/-/client-sns-3.1044.0.tgz",
+      "integrity": "sha512-0vcufJrms7t4dV9yO2N71t2Nme2mavOm51eaeXEcjMRow2DY64aIqe9pO7NE+WwMeE1RqN0tUy9mH9wRaxC2/Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.974.8",
+        "@aws-sdk/credential-provider-node": "^3.972.39",
+        "@aws-sdk/middleware-host-header": "^3.972.10",
+        "@aws-sdk/middleware-logger": "^3.972.10",
+        "@aws-sdk/middleware-recursion-detection": "^3.972.11",
+        "@aws-sdk/middleware-user-agent": "^3.972.38",
+        "@aws-sdk/region-config-resolver": "^3.972.13",
+        "@aws-sdk/types": "^3.973.8",
+        "@aws-sdk/util-endpoints": "^3.996.8",
+        "@aws-sdk/util-user-agent-browser": "^3.972.10",
+        "@aws-sdk/util-user-agent-node": "^3.973.24",
+        "@smithy/config-resolver": "^4.4.17",
+        "@smithy/core": "^3.23.17",
+        "@smithy/fetch-http-handler": "^5.3.17",
+        "@smithy/hash-node": "^4.2.14",
+        "@smithy/invalid-dependency": "^4.2.14",
+        "@smithy/middleware-content-length": "^4.2.14",
+        "@smithy/middleware-endpoint": "^4.4.32",
+        "@smithy/middleware-retry": "^4.5.7",
+        "@smithy/middleware-serde": "^4.2.20",
+        "@smithy/middleware-stack": "^4.2.14",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/node-http-handler": "^4.6.1",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/smithy-client": "^4.12.13",
+        "@smithy/types": "^4.14.1",
+        "@smithy/url-parser": "^4.2.14",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-body-length-browser": "^4.2.2",
+        "@smithy/util-body-length-node": "^4.2.3",
+        "@smithy/util-defaults-mode-browser": "^4.3.49",
+        "@smithy/util-defaults-mode-node": "^4.2.54",
+        "@smithy/util-endpoints": "^3.4.2",
+        "@smithy/util-middleware": "^4.2.14",
+        "@smithy/util-retry": "^4.3.6",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sqs": {
+      "version": "3.1045.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sqs/-/client-sqs-3.1045.0.tgz",
+      "integrity": "sha512-reWeEE53mgCv8uUFSicvVf0A6BoWGImdC4y5x5clkeEmfIikahIBtons6u0d32kwI4NczpcretpUkOCE/nvWAA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.974.8",
+        "@aws-sdk/credential-provider-node": "^3.972.39",
+        "@aws-sdk/middleware-host-header": "^3.972.10",
+        "@aws-sdk/middleware-logger": "^3.972.10",
+        "@aws-sdk/middleware-recursion-detection": "^3.972.11",
+        "@aws-sdk/middleware-sdk-sqs": "^3.972.22",
+        "@aws-sdk/middleware-user-agent": "^3.972.38",
+        "@aws-sdk/region-config-resolver": "^3.972.13",
+        "@aws-sdk/types": "^3.973.8",
+        "@aws-sdk/util-endpoints": "^3.996.8",
+        "@aws-sdk/util-user-agent-browser": "^3.972.10",
+        "@aws-sdk/util-user-agent-node": "^3.973.24",
+        "@smithy/config-resolver": "^4.4.17",
+        "@smithy/core": "^3.23.17",
+        "@smithy/fetch-http-handler": "^5.3.17",
+        "@smithy/hash-node": "^4.2.14",
+        "@smithy/invalid-dependency": "^4.2.14",
+        "@smithy/md5-js": "^4.2.14",
+        "@smithy/middleware-content-length": "^4.2.14",
+        "@smithy/middleware-endpoint": "^4.4.32",
+        "@smithy/middleware-retry": "^4.5.7",
+        "@smithy/middleware-serde": "^4.2.20",
+        "@smithy/middleware-stack": "^4.2.14",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/node-http-handler": "^4.6.1",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/smithy-client": "^4.12.13",
+        "@smithy/types": "^4.14.1",
+        "@smithy/url-parser": "^4.2.14",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-body-length-browser": "^4.2.2",
+        "@smithy/util-body-length-node": "^4.2.3",
+        "@smithy/util-defaults-mode-browser": "^4.3.49",
+        "@smithy/util-defaults-mode-node": "^4.2.54",
+        "@smithy/util-endpoints": "^3.4.2",
+        "@smithy/util-middleware": "^4.2.14",
+        "@smithy/util-retry": "^4.3.6",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/core": {
+      "version": "3.974.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.8.tgz",
+      "integrity": "sha512-njR2qoG6ZuB0kvAS2FyICsFZJ6gmCcf2X/7JcD14sUvGDm26wiZ5BrA6LOiUxKFEF+IVe7kdroxyE00YlkiYsw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@aws-sdk/xml-builder": "^3.972.22",
+        "@smithy/core": "^3.23.17",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/signature-v4": "^5.3.14",
+        "@smithy/smithy-client": "^4.12.13",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-middleware": "^4.2.14",
+        "@smithy/util-retry": "^4.3.6",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.972.34",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.34.tgz",
+      "integrity": "sha512-XT0jtf8Fw9JE6ppsQeoNnZRiG+jqRixMT1v1ZR17G60UvVdsQmTG8nbEyHuEPfMxDXEhfdARaM/XiEhca4lGHQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.8",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.972.36",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.36.tgz",
+      "integrity": "sha512-DPoGWfy7J7RKxvbf5kOKIGQkD2ek3dbKgzKIGrnLuvZBz5myU+Im/H6pmc14QcnFbqHMqxvtWSgRDSJW3qXLQg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.8",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/fetch-http-handler": "^5.3.17",
+        "@smithy/node-http-handler": "^4.6.1",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/smithy-client": "^4.12.13",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-stream": "^4.5.25",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.972.38",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.38.tgz",
+      "integrity": "sha512-oDzUBu2MGJFgoar05sPMCwSrhw44ASyccrHzj66vO69OZqi7I6hZZxXfuPLC8OCzW7C+sU+bI73XHij41yekgQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.8",
+        "@aws-sdk/credential-provider-env": "^3.972.34",
+        "@aws-sdk/credential-provider-http": "^3.972.36",
+        "@aws-sdk/credential-provider-login": "^3.972.38",
+        "@aws-sdk/credential-provider-process": "^3.972.34",
+        "@aws-sdk/credential-provider-sso": "^3.972.38",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.38",
+        "@aws-sdk/nested-clients": "^3.997.6",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/credential-provider-imds": "^4.2.14",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-login": {
+      "version": "3.972.38",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.38.tgz",
+      "integrity": "sha512-g1NosS8qe4OF++G2UFCM5ovSkgipC7YYor5KCWatG0UoMSO5YFj9C8muePlyVmOBV/WTI16Jo3/s1NUo/o1Bww==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.8",
+        "@aws-sdk/nested-clients": "^3.997.6",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.972.39",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.39.tgz",
+      "integrity": "sha512-HEswDQyxUtadoZ/bJsPPENHg7R0Lzym5LuMksJeHvqhCOpP+rtkDLKI4/ZChH4w3cf5kG8n6bZuI8PzajoiqMg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "^3.972.34",
+        "@aws-sdk/credential-provider-http": "^3.972.36",
+        "@aws-sdk/credential-provider-ini": "^3.972.38",
+        "@aws-sdk/credential-provider-process": "^3.972.34",
+        "@aws-sdk/credential-provider-sso": "^3.972.38",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.38",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/credential-provider-imds": "^4.2.14",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.972.34",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.34.tgz",
+      "integrity": "sha512-T3IFs4EVmVi1dVN5RciFnklCANSzvrQd/VuHY9ThHSQmYkTogjcGkoJEr+oNUPQZnso52183088NqysMPji1/Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.8",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.972.38",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.38.tgz",
+      "integrity": "sha512-5ZxG+t0+3Q3QPh8KEjX6syskhgNf7I0MN7oGioTf6Lm1NTjfP7sIcYGNsthXC2qR8vcD3edNZwCr2ovfSSWuRA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.8",
+        "@aws-sdk/nested-clients": "^3.997.6",
+        "@aws-sdk/token-providers": "3.1041.0",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.972.38",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.38.tgz",
+      "integrity": "sha512-lYHFF30DGI20jZcYX8cm6Ns0V7f1dDN6g/MBDLTyD/5iw+bXs3yBr2iAiHDkx4RFU5JgsnZvCHYKiRVPRdmOgw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.8",
+        "@aws-sdk/nested-clients": "^3.997.6",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/dynamodb-codec": {
+      "version": "3.973.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/dynamodb-codec/-/dynamodb-codec-3.973.8.tgz",
+      "integrity": "sha512-dYQ/cQqHZd23hcl8oEGwPphTqyGnmvf2HrVmz4J90Q5Bv89oJjlwcBcifiiTvApqsVpx7Pr0IebMpkYwWJvZlQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.8",
+        "@smithy/core": "^3.23.17",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-base64": "^4.3.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/endpoint-cache": {
+      "version": "3.972.5",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/endpoint-cache/-/endpoint-cache-3.972.5.tgz",
+      "integrity": "sha512-itVdge0NozgtgmtbZ25FVwWU3vGlE7x7feE/aOEJNkQfEpbkrF8Rj1QmnK+2blFfYE1xWt/iU+6/jUp/pv1+MA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "mnemonist": "0.38.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-endpoint-discovery": {
+      "version": "3.972.11",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint-discovery/-/middleware-endpoint-discovery-3.972.11.tgz",
+      "integrity": "sha512-vXARCZVFQHdsd6qPPZyC/hh+5x2XsCYKqUQDCqnUlpGpChMpDojOOacQWdLJ+FFXKN8X3cmLOGrtgx/zysCKqQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/endpoint-cache": "^3.972.5",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-host-header": {
+      "version": "3.972.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.972.10.tgz",
+      "integrity": "sha512-IJSsIMeVQ8MMCPbuh1AbltkFhLBLXn7aejzfX5YKT/VLDHn++Dcz8886tXckE+wQssyPUhaXrJhdakO2VilRhg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-logger": {
+      "version": "3.972.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.972.10.tgz",
+      "integrity": "sha512-OOuGvvz1Dm20SjZo5oEBePFqxt5nf8AwkNDSyUHvD9/bfNASmstcYxFAHUowy4n6Io7mWUZ04JURZwSBvyQanQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-recursion-detection": {
+      "version": "3.972.11",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.972.11.tgz",
+      "integrity": "sha512-+zz6f79Kj9V5qFK2P+D8Ehjnw4AhphAlCAsPjUqEcInA9umtSSKMrHbSagEeOIsDNuvVrH98bjRHcyQukTrhaQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@aws/lambda-invoke-store": "^0.2.2",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-s3": {
+      "version": "3.972.37",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.37.tgz",
+      "integrity": "sha512-Km7M+i8DrLArVzrid1gfxeGhYHBd3uxvE77g0s5a52zPSVosxzQBnJ0gwWb6NIp/DOk8gsBMhi7V+cpJG0ndTA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.8",
+        "@aws-sdk/types": "^3.973.8",
+        "@aws-sdk/util-arn-parser": "^3.972.3",
+        "@smithy/core": "^3.23.17",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/signature-v4": "^5.3.14",
+        "@smithy/smithy-client": "^4.12.13",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-config-provider": "^4.2.2",
+        "@smithy/util-middleware": "^4.2.14",
+        "@smithy/util-stream": "^4.5.25",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-sqs": {
+      "version": "3.972.22",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sqs/-/middleware-sdk-sqs-3.972.22.tgz",
+      "integrity": "sha512-DtR3mEiOUJcnEX/QuXmvbJto6xvQzp2ftnHb29c0aQYdmmzbKf0gsu9ovx1i/yy4ZR6m0rttTucS0iiP32dlGA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/smithy-client": "^4.12.13",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-hex-encoding": "^4.2.2",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-user-agent": {
+      "version": "3.972.38",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.972.38.tgz",
+      "integrity": "sha512-iz+B29TXcAZsJpwB+AwG/TTGA5l/VnmMZ2UxtiySOZjI6gCdmviXPwdgzcmuazMy16rXoPY4mYCGe7zdNKfx5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.8",
+        "@aws-sdk/types": "^3.973.8",
+        "@aws-sdk/util-endpoints": "^3.996.8",
+        "@smithy/core": "^3.23.17",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-retry": "^4.3.6",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/nested-clients": {
+      "version": "3.997.6",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.6.tgz",
+      "integrity": "sha512-WBDnqatJl+kGObpfmfSxqnXeYTu3Me8wx8WCtvoxX3pfWrrTv8I4WTMSSs7PZqcRcVh8WeUKMgGFjMG+52SR1w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.974.8",
+        "@aws-sdk/middleware-host-header": "^3.972.10",
+        "@aws-sdk/middleware-logger": "^3.972.10",
+        "@aws-sdk/middleware-recursion-detection": "^3.972.11",
+        "@aws-sdk/middleware-user-agent": "^3.972.38",
+        "@aws-sdk/region-config-resolver": "^3.972.13",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.25",
+        "@aws-sdk/types": "^3.973.8",
+        "@aws-sdk/util-endpoints": "^3.996.8",
+        "@aws-sdk/util-user-agent-browser": "^3.972.10",
+        "@aws-sdk/util-user-agent-node": "^3.973.24",
+        "@smithy/config-resolver": "^4.4.17",
+        "@smithy/core": "^3.23.17",
+        "@smithy/fetch-http-handler": "^5.3.17",
+        "@smithy/hash-node": "^4.2.14",
+        "@smithy/invalid-dependency": "^4.2.14",
+        "@smithy/middleware-content-length": "^4.2.14",
+        "@smithy/middleware-endpoint": "^4.4.32",
+        "@smithy/middleware-retry": "^4.5.7",
+        "@smithy/middleware-serde": "^4.2.20",
+        "@smithy/middleware-stack": "^4.2.14",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/node-http-handler": "^4.6.1",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/smithy-client": "^4.12.13",
+        "@smithy/types": "^4.14.1",
+        "@smithy/url-parser": "^4.2.14",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-body-length-browser": "^4.2.2",
+        "@smithy/util-body-length-node": "^4.2.3",
+        "@smithy/util-defaults-mode-browser": "^4.3.49",
+        "@smithy/util-defaults-mode-node": "^4.2.54",
+        "@smithy/util-endpoints": "^3.4.2",
+        "@smithy/util-middleware": "^4.2.14",
+        "@smithy/util-retry": "^4.3.6",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/region-config-resolver": {
+      "version": "3.972.13",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.13.tgz",
+      "integrity": "sha512-CvJ2ZIjK/jVD/lbOpowBVElJyC1YxLTIJ13yM0AEo0t2v7swOzGjSA6lJGH+DwZXQhcjUjoYwc8bVYCX5MDr1A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/config-resolver": "^4.4.17",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/signature-v4-multi-region": {
+      "version": "3.996.25",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.25.tgz",
+      "integrity": "sha512-+CMIt3e1VzlklAECmG+DtP1sV8iKq25FuA0OKpnJ4KA0kxUtd7CgClY7/RU6VzJBQwbN4EJ9Ue6plvqx1qGadw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/middleware-sdk-s3": "^3.972.37",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/signature-v4": "^5.3.14",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/token-providers": {
+      "version": "3.1041.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1041.0.tgz",
+      "integrity": "sha512-Th7kPI6YPtvJUcdznooXJMy+9rQWjmEF81LxaJssngBzuysK4a/x+l8kjm1zb7nYsUPbndnBdUnwng/3PLvtGw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.8",
+        "@aws-sdk/nested-clients": "^3.997.6",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/types": {
+      "version": "3.973.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.8.tgz",
+      "integrity": "sha512-gjlAdtHMbtR9X5iIhVUvbVcy55KnznpC6bkDUWW9z915bi0ckdUr5cjf16Kp6xq0bP5HBD2xzgbL9F9Quv5vUw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-arn-parser": {
+      "version": "3.972.3",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.972.3.tgz",
+      "integrity": "sha512-HzSD8PMFrvgi2Kserxuff5VitNq2sgf3w9qxmskKDiDTThWfVteJxuCS9JXiPIPtmCrp+7N9asfIaVhBFORllA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-endpoints": {
+      "version": "3.996.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.996.8.tgz",
+      "integrity": "sha512-oOZHcRDihk5iEe5V25NVWg45b3qEA8OpHWVdU/XQh8Zj4heVPAJqWvMphQnU7LkufmUo10EpvFPZuQMiFLJK3g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/types": "^4.14.1",
+        "@smithy/url-parser": "^4.2.14",
+        "@smithy/util-endpoints": "^3.4.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-locate-window": {
+      "version": "3.965.5",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.965.5.tgz",
+      "integrity": "sha512-WhlJNNINQB+9qtLtZJcpQdgZw3SCDCpXdUJP7cToGwHbCWCnRckGlc6Bx/OhWwIYFNAn+FIydY8SZ0QmVu3xTQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-user-agent-browser": {
+      "version": "3.972.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.972.10.tgz",
+      "integrity": "sha512-FAzqXvfEssGdSIz8ejatan0bOdx1qefBWKF/gWmVBXIP1HkS7v/wjjaqrAGGKvyihrXTXW00/2/1nTJtxpXz7g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/types": "^4.14.1",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.973.24",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.973.24.tgz",
+      "integrity": "sha512-ZWwlkjcIp7cEL8ZfTpTAPNkwx25p7xol0xlKoWVVf22+nsjwmLcHYtTPjIV1cSpmB/b6DaK4cb1fSkvCXHgRdw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/middleware-user-agent": "^3.972.38",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-config-provider": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "aws-crt": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "aws-crt": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@aws-sdk/xml-builder": {
+      "version": "3.972.22",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.22.tgz",
+      "integrity": "sha512-PMYKKtJd70IsSG0yHrdAbxBr+ZWBKLvzFZfD3/urxgf6hXVMzuU5M+3MJ5G67RpOmLBu1fAUN65SbWuKUCOlAA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@nodable/entities": "2.1.0",
+        "@smithy/types": "^4.14.1",
+        "fast-xml-parser": "5.7.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws/lambda-invoke-store": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.4.tgz",
+      "integrity": "sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@babel/helper-string-parser": {
@@ -728,6 +1778,18 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@nodable/entities": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
+      "integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.60.1",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.1.tgz",
@@ -1127,6 +2189,677 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@smithy/config-resolver": {
+      "version": "4.4.17",
+      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.4.17.tgz",
+      "integrity": "sha512-TzDZcAnhTyAHbXVxWZo7/tEcrIeFq20IBk8So3OLOetWpR8EwY/yEqBMBFaJMeyEiREDq4NfEl+qO3OAUD+vbQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-config-provider": "^4.2.2",
+        "@smithy/util-endpoints": "^3.4.2",
+        "@smithy/util-middleware": "^4.2.14",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/core": {
+      "version": "3.23.17",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.23.17.tgz",
+      "integrity": "sha512-x7BlLbUFL8NWCGjMF9C+1N5cVCxcPa7g6Tv9B4A2luWx3be3oU8hQ96wIwxe/s7OhIzvoJH73HAUSg5JXVlEtQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
+        "@smithy/url-parser": "^4.2.14",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-body-length-browser": "^4.2.2",
+        "@smithy/util-middleware": "^4.2.14",
+        "@smithy/util-stream": "^4.5.25",
+        "@smithy/util-utf8": "^4.2.2",
+        "@smithy/uuid": "^1.1.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/credential-provider-imds": {
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.2.14.tgz",
+      "integrity": "sha512-Au28zBN48ZAoXdooGUHemuVBrkE+Ie6RPmGNIAJsFqj33Vhb6xAgRifUydZ2aY+M+KaMAETAlKk5NC5h1G7wpg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/types": "^4.14.1",
+        "@smithy/url-parser": "^4.2.14",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/eventstream-codec": {
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-4.2.14.tgz",
+      "integrity": "sha512-erZq0nOIpzfeZdCyzZjdJb4nVSKLUmSkaQUVkRGQTXs30gyUGeKnrYEg+Xe1W5gE3aReS7IgsvANwVPxSzY6Pw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/crc32": "5.2.0",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-hex-encoding": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/eventstream-serde-browser": {
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-browser/-/eventstream-serde-browser-4.2.14.tgz",
+      "integrity": "sha512-8IelTCtTctWRbb+0Dcy+C0aICh1qa0qWXqgjcXDmMuCvPJRnv26hiDZoAau2ILOniki65mCPKqOQs/BaWvO4CQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/eventstream-serde-universal": "^4.2.14",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/eventstream-serde-config-resolver": {
+      "version": "4.3.14",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-4.3.14.tgz",
+      "integrity": "sha512-sqHiHpYRYo3FJlaIxD1J8PhbcmJAm7IuM16mVnwSkCToD7g00IBZzKuiLNMGmftULmEUX6/UAz8/NN5uMP8bVA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/eventstream-serde-node": {
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-node/-/eventstream-serde-node-4.2.14.tgz",
+      "integrity": "sha512-Ht/8BuGlKfFTy0H3+8eEu0vdpwGztCnaLLXtpXNdQqiR7Hj4vFScU3T436vRAjATglOIPjJXronY+1WxxNLSiw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/eventstream-serde-universal": "^4.2.14",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/eventstream-serde-universal": {
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-universal/-/eventstream-serde-universal-4.2.14.tgz",
+      "integrity": "sha512-lWyt4T2XQZUZgK3tQ3Wn0w3XBvZsK/vjTuJl6bXbnGZBHH0ZUSONTYiK9TgjTTzU54xQr3DRFwpjmhp0oLm3gg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/eventstream-codec": "^4.2.14",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/fetch-http-handler": {
+      "version": "5.3.17",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.3.17.tgz",
+      "integrity": "sha512-bXOvQzaSm6MnmLaWA1elgfQcAtN4UP3vXqV97bHuoOrHQOJiLT3ds6o9eo5bqd0TJfRFpzdGnDQdW3FACiAVdw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/querystring-builder": "^4.2.14",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-base64": "^4.3.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/hash-node": {
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.2.14.tgz",
+      "integrity": "sha512-8ZBDY2DD4wr+GGjTpPtiglEsqr0lUP+KHqgZcWczFf6qeZ/YRjMIOoQWVQlmwu7EtxKTd8YXD8lblmYcpBIA1g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-buffer-from": "^4.2.2",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/invalid-dependency": {
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.2.14.tgz",
+      "integrity": "sha512-c21qJiTSb25xvvOp+H2TNZzPCngrvl5vIPqPB8zQ/DmJF4QWXO19x1dWfMJZ6wZuuWUPPm0gV8C0cU3+ifcWuw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/is-array-buffer": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.2.2.tgz",
+      "integrity": "sha512-n6rQ4N8Jj4YTQO3YFrlgZuwKodf4zUFs7EJIWH86pSCWBaAtAGBFfCM7Wx6D2bBJ2xqFNxGBSrUWswT3M0VJow==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/md5-js": {
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/md5-js/-/md5-js-4.2.14.tgz",
+      "integrity": "sha512-V2v0vx+h0iUSNG1Alt+GNBMSLGCrl9iVsdd+Ap67HPM9PN479x12V8LkuMoKImNZxn3MXeuyUjls+/7ZACZghA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-content-length": {
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.2.14.tgz",
+      "integrity": "sha512-xhHq7fX4/3lv5NHxLUk3OeEvl0xZ+Ek3qIbWaCL4f9JwgDZEclPBElljaZCAItdGPQl/kSM4LPMOpy1MYgprpw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-endpoint": {
+      "version": "4.4.32",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.4.32.tgz",
+      "integrity": "sha512-ZZkgyjnJppiZbIm6Qbx92pbXYi1uzenIvGhBSCDlc7NwuAkiqSgS75j1czAD25ZLs2FjMjYy1q7gyRVWG6JA0Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.23.17",
+        "@smithy/middleware-serde": "^4.2.20",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
+        "@smithy/url-parser": "^4.2.14",
+        "@smithy/util-middleware": "^4.2.14",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-retry": {
+      "version": "4.5.7",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.5.7.tgz",
+      "integrity": "sha512-bRt6ZImqVSeTk39Nm81K20ObIiAZ3WefY7G6+iz/0tZjs4dgRRjvRX2sgsH+zi6iDCRR/aQvQofLKxxz4rPBZg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.23.17",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/service-error-classification": "^4.3.1",
+        "@smithy/smithy-client": "^4.12.13",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-middleware": "^4.2.14",
+        "@smithy/util-retry": "^4.3.6",
+        "@smithy/uuid": "^1.1.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-serde": {
+      "version": "4.2.20",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.2.20.tgz",
+      "integrity": "sha512-Lx9JMO9vArPtiChE3wbEZ5akMIDQpWQtlu90lhACQmNOXcGXRbaDywMHDzuDZ2OkZzP+9wQfZi3YJT9F67zTQQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.23.17",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-stack": {
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.2.14.tgz",
+      "integrity": "sha512-2dvkUKLuFdKsCRmOE4Mn63co0Djtsm+JMh0bYZQupN1pJwMeE8FmQmRLLzzEMN0dnNi7CDCYYH8F0EVwWiPBeA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/node-config-provider": {
+      "version": "4.3.14",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.3.14.tgz",
+      "integrity": "sha512-S+gFjyo/weSVL0P1b9Ts8C/CwIfNCgUPikk3sl6QVsfE/uUuO+QsF+NsE/JkpvWqqyz1wg7HFdiaZuj5CoBMRg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/node-http-handler": {
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.6.1.tgz",
+      "integrity": "sha512-iB+orM4x3xrr57X3YaXazfKnntl0LHlZB1kcXSGzMV1Tt0+YwEjGlbjk/44qEGtBzXAz6yFDzkYTKSV6Pj2HUg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/querystring-builder": "^4.2.14",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/property-provider": {
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.2.14.tgz",
+      "integrity": "sha512-WuM31CgfsnQ/10i7NYr0PyxqknD72Y5uMfUMVSniPjbEPceiTErb4eIqJQ+pdxNEAUEWrewrGjIRjVbVHsxZiQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/protocol-http": {
+      "version": "5.3.14",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.14.tgz",
+      "integrity": "sha512-dN5F8kHx8RNU0r+pCwNmFZyz6ChjMkzShy/zup6MtkRmmix4vZzJdW+di7x//b1LiynIev88FM18ie+wwPcQtQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/querystring-builder": {
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.2.14.tgz",
+      "integrity": "sha512-XYA5Z0IqTeF+5XDdh4BBmSA0HvbgVZIyv4cmOoUheDNR57K1HgBp9ukUMx3Cr3XpDHHpLBnexPE3LAtDsZkj2A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-uri-escape": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/querystring-parser": {
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.2.14.tgz",
+      "integrity": "sha512-hr+YyqBD23GVvRxGGrcc/oOeNlK3PzT5Fu4dzrDXxzS1LpFiuL2PQQqKPs87M79aW7ziMs+nvB3qdw77SqE7Lw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/service-error-classification": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.3.1.tgz",
+      "integrity": "sha512-aUQuDGh760ts/8MU+APjIZhlLPKhIIfqyzZaJikLEIMrdxFvxuLYD0WxWzaYWpmLbQlXDe9p7EWM3HsBe0K6Gw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/shared-ini-file-loader": {
+      "version": "4.4.9",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.4.9.tgz",
+      "integrity": "sha512-495/V2I15SHgedSJoDPD23JuSfKAp726ZI1V0wtjB07Wh7q/0tri/0e0DLefZCHgxZonrGKt/OCTpAtP1wE1kQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/signature-v4": {
+      "version": "5.3.14",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.3.14.tgz",
+      "integrity": "sha512-1D9Y/nmlVjCeSivCbhZ7hgEpmHyY1h0GvpSZt3l0xcD9JjmjVC1CHOozS6+Gh+/ldMH8JuJ6cujObQqfayAVFA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^4.2.2",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-hex-encoding": "^4.2.2",
+        "@smithy/util-middleware": "^4.2.14",
+        "@smithy/util-uri-escape": "^4.2.2",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/smithy-client": {
+      "version": "4.12.13",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.12.13.tgz",
+      "integrity": "sha512-y/Pcj1V9+qG98gyu1gvftHB7rDpdh+7kIBIggs55yGm3JdtBV8GT8IFF3a1qxZ79QnaJHX9GXzvBG6tAd+czJA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.23.17",
+        "@smithy/middleware-endpoint": "^4.4.32",
+        "@smithy/middleware-stack": "^4.2.14",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-stream": "^4.5.25",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/types": {
+      "version": "4.14.1",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.1.tgz",
+      "integrity": "sha512-59b5HtSVrVR/eYNei3BUj3DCPKD/G7EtDDe7OEJE7i7FtQFugYo6MxbotS8mVJkLNVf8gYaAlEBwwtJ9HzhWSg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/url-parser": {
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.2.14.tgz",
+      "integrity": "sha512-p06BiBigJ8bTA3MgnOfCtDUWnAMY0YfedO/GRpmc7p+wg3KW8vbXy1xwSu5ASy0wV7rRYtlfZOIKH4XqfhjSQQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/querystring-parser": "^4.2.14",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-base64": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-4.3.2.tgz",
+      "integrity": "sha512-XRH6b0H/5A3SgblmMa5ErXQ2XKhfbQB+Fm/oyLZ2O2kCUrwgg55bU0RekmzAhuwOjA9qdN5VU2BprOvGGUkOOQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^4.2.2",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-body-length-browser": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-4.2.2.tgz",
+      "integrity": "sha512-JKCrLNOup3OOgmzeaKQwi4ZCTWlYR5H4Gm1r2uTMVBXoemo1UEghk5vtMi1xSu2ymgKVGW631e2fp9/R610ZjQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-body-length-node": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-4.2.3.tgz",
+      "integrity": "sha512-ZkJGvqBzMHVHE7r/hcuCxlTY8pQr1kMtdsVPs7ex4mMU+EAbcXppfo5NmyxMYi2XU49eqaz56j2gsk4dHHPG/g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-buffer-from": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.2.2.tgz",
+      "integrity": "sha512-FDXD7cvUoFWwN6vtQfEta540Y/YBe5JneK3SoZg9bThSoOAC/eGeYEua6RkBgKjGa/sz6Y+DuBZj3+YEY21y4Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-config-provider": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-4.2.2.tgz",
+      "integrity": "sha512-dWU03V3XUprJwaUIFVv4iOnS1FC9HnMHDfUrlNDSh4315v0cWyaIErP8KiqGVbf5z+JupoVpNM7ZB3jFiTejvQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-defaults-mode-browser": {
+      "version": "4.3.49",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.3.49.tgz",
+      "integrity": "sha512-a5bNrdiONYB/qE2BuKegvUMd/+ZDwdg4vsNuuSzYE8qs2EYAdK9CynL+Rzn29PbPiUqoz/cbpRbcLzD5lEevHw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/smithy-client": "^4.12.13",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-defaults-mode-node": {
+      "version": "4.2.54",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.2.54.tgz",
+      "integrity": "sha512-g1cvrJvOnzeJgEdf7AE4luI7gp6L8weE0y9a9wQUSGtjb8QRHDbCJYuE4Sy0SD9N8RrnNPFsPltAz/OSoBR9Zw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/config-resolver": "^4.4.17",
+        "@smithy/credential-provider-imds": "^4.2.14",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/smithy-client": "^4.12.13",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-endpoints": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.4.2.tgz",
+      "integrity": "sha512-a55Tr+3OKld4TTtnT+RhKOQHyPxm3j/xL4OR83WBUhLJaKDS9dnJ7arRMOp3t31dcLhApwG9bgvrRXBHlLdIkg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-hex-encoding": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-4.2.2.tgz",
+      "integrity": "sha512-Qcz3W5vuHK4sLQdyT93k/rfrUwdJ8/HZ+nMUOyGdpeGA1Wxt65zYwi3oEl9kOM+RswvYq90fzkNDahPS8K0OIg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-middleware": {
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.14.tgz",
+      "integrity": "sha512-1Su2vj9RYNDEv/V+2E+jXkkwGsgR7dc4sfHn9Z7ruzQHJIEni9zzw5CauvRXlFJfmgcqYP8fWa0dkh2Q2YaQyw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-retry": {
+      "version": "4.3.8",
+      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.3.8.tgz",
+      "integrity": "sha512-LUIxbTBi+OpvXpg91poGA6BdyoleMDLnfXjVDqyi2RvZmTveY5loE/FgYUBCR5LU2BThW2SoZRh8dTIIy38IPw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/service-error-classification": "^4.3.1",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-stream": {
+      "version": "4.5.25",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.5.25.tgz",
+      "integrity": "sha512-/PFpG4k8Ze8Ei+mMKj3oiPICYekthuzePZMgZbCqMiXIHHf4n2aZ4Ps0aSRShycFTGuj/J6XldmC0x0DwednIA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/fetch-http-handler": "^5.3.17",
+        "@smithy/node-http-handler": "^4.6.1",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-buffer-from": "^4.2.2",
+        "@smithy/util-hex-encoding": "^4.2.2",
+        "@smithy/util-utf8": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-uri-escape": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.2.2.tgz",
+      "integrity": "sha512-2kAStBlvq+lTXHyAZYfJRb/DfS3rsinLiwb+69SstC9Vb0s9vNWkRwpnj918Pfi85mzi42sOqdV72OLxWAISnw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-utf8": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.2.tgz",
+      "integrity": "sha512-75MeYpjdWRe8M5E3AW0O4Cx3UadweS+cwdXjwYGBW5h/gxxnbeZ877sLPX/ZJA9GVTlL/qG0dXP29JWFCD1Ayw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^4.2.2",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-waiter": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-4.3.0.tgz",
+      "integrity": "sha512-JyjYmLAfS+pdxF92o4yLgEoy0zhayKTw73FU1aofLWwLcJw7iSqIY2exGmMTrl/lmZugP5p/zxdFSippJDfKWA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/uuid": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@smithy/uuid/-/uuid-1.1.2.tgz",
+      "integrity": "sha512-O/IEdcCUKkubz60tFbGA7ceITTAJsty+lBjNoorP4Z6XRqaFb/OjQjZODophEcuq68nKm6/0r+6/lLQ+XVpk8g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
@@ -1170,9 +2903,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "20.19.30",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.30.tgz",
-      "integrity": "sha512-WJtwWJu7UdlvzEAUm484QNg5eAoq5QR08KDNx7g45Usrs2NtOPiX8ugDqmKdXkyL03rBqU5dYNYVQetEpBHq2g==",
+      "version": "20.19.39",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.39.tgz",
+      "integrity": "sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1357,6 +3090,12 @@
         "js-tokens": "^9.0.1"
       }
     },
+    "node_modules/aws4": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.13.2.tgz",
+      "integrity": "sha512-lHe62zvbTB5eEABUVi/AwVh0ZKY9rMMDhmm+eeyuuUQbQ3+J+fONVQOZyj+DdrvD4BY33uYniyRJ4UJIaSKAfw==",
+      "license": "MIT"
+    },
     "node_modules/balanced-match": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
@@ -1366,6 +3105,12 @@
       "engines": {
         "node": "18 || 20 || >=22"
       }
+    },
+    "node_modules/bowser": {
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
+      "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
+      "license": "MIT"
     },
     "node_modules/brace-expansion": {
       "version": "5.0.5",
@@ -1470,6 +3215,42 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fast-xml-builder": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.9.tgz",
+      "integrity": "sha512-jcyKVSEX13iseJqg7n/KWw+xnu/7fdrZ333Fac54KjHDIELVCfDDJXYIm6DTJ0Su4gSzrhqiK0DzY/wZbF40mw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "path-expression-matcher": "^1.1.3"
+      }
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.2.tgz",
+      "integrity": "sha512-P7oW7tLbYnhOLQk/Gv7cZgzgMPP/XN03K02/Jy6Y/NHzyIAIpxuZIM/YqAkfiXFPxA2CTm7NtCijK9EDu09u2w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@nodable/entities": "^2.1.0",
+        "fast-xml-builder": "^1.1.5",
+        "path-expression-matcher": "^1.5.0",
+        "strnum": "^2.2.3"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
       }
     },
     "node_modules/fdir": {
@@ -1702,6 +3483,15 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
+    "node_modules/mnemonist": {
+      "version": "0.38.3",
+      "resolved": "https://registry.npmjs.org/mnemonist/-/mnemonist-0.38.3.tgz",
+      "integrity": "sha512-2K9QYubXx/NAjv4VLq1d1Ly8pWNC5L3BrixtdkyTegXWJIqY+zLNDhhX/A+ZwWt70tB1S8H4BE8FLYEFyNoOBw==",
+      "license": "MIT",
+      "dependencies": {
+        "obliterator": "^1.6.1"
+      }
+    },
     "node_modules/nanoid": {
       "version": "3.3.11",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
@@ -1721,6 +3511,12 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/obliterator": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/obliterator/-/obliterator-1.6.1.tgz",
+      "integrity": "sha512-9WXswnqINnnhOG/5SLimUlzuU1hFJUc8zkwyD59Sd+dPOMf05PmnYG/d6Q7HZ+KmgkZJa1PxRso6QdM3sTNHig==",
+      "license": "MIT"
+    },
     "node_modules/obug": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
@@ -1738,6 +3534,21 @@
       "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
       "dev": true,
       "license": "BlueOak-1.0.0"
+    },
+    "node_modules/path-expression-matcher": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
+      "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
     },
     "node_modules/path-scurry": {
       "version": "2.0.1",
@@ -1931,6 +3742,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/strnum": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.3.0.tgz",
+      "integrity": "sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -1987,6 +3810,12 @@
       "engines": {
         "node": ">=14.0.0"
       }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
     },
     "node_modules/typedoc": {
       "version": "0.28.18",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,17 +8,15 @@
       "name": "@sanity/functions",
       "version": "1.3.1",
       "license": "MIT",
-      "dependencies": {
+      "devDependencies": {
         "@aws-lite/client": "^0.23.6",
         "@aws-lite/dynamodb": "^0.3.9",
         "@aws-lite/dynamodb-types": "^0.3.12",
         "@aws-lite/lambda": "^0.1.5",
+        "@aws-lite/lambda-types": "^0.1.6",
         "@aws-lite/sns": "^0.0.8",
         "@aws-lite/sns-types": "^0.0.11",
-        "@aws-lite/sqs": "^0.2.4"
-      },
-      "devDependencies": {
-        "@aws-lite/lambda-types": "^0.1.6",
+        "@aws-lite/sqs": "^0.2.4",
         "@aws-lite/sqs-types": "^0.2.7",
         "@biomejs/biome": "2.3.12",
         "@types/node": "^20.19.39",
@@ -30,6 +28,13 @@
       },
       "engines": {
         "node": ">=20.19"
+      },
+      "peerDependencies": {
+        "@aws-lite/client": "^0.23.6",
+        "@aws-lite/dynamodb": "^0.3.9",
+        "@aws-lite/lambda": "^0.1.5",
+        "@aws-lite/sns": "^0.0.8",
+        "@aws-lite/sqs": "^0.2.4"
       }
     },
     "node_modules/@aws-crypto/crc32": {
@@ -51,6 +56,7 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
       "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-js": "^5.2.0",
@@ -66,6 +72,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
       "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -78,6 +85,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
       "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/is-array-buffer": "^2.2.0",
@@ -91,6 +99,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
       "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/util-buffer-from": "^2.2.0",
@@ -104,6 +113,7 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
       "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/util": "^5.2.0",
@@ -118,6 +128,7 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
       "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -127,6 +138,7 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
       "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "^3.222.0",
@@ -138,6 +150,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
       "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -150,6 +163,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
       "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/is-array-buffer": "^2.2.0",
@@ -163,6 +177,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
       "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/util-buffer-from": "^2.2.0",
@@ -176,6 +191,7 @@
       "version": "0.23.6",
       "resolved": "https://registry.npmjs.org/@aws-lite/client/-/client-0.23.6.tgz",
       "integrity": "sha512-37oDevQKNCv5GpZ+4J7awO7B4BfHMisek6Z3ofEE9XOmxMrRrLnBBH8/Qf/ByR/qpygy293WW4ekVNiR1MUu+Q==",
+      "dev": true,
       "license": "Apache-2.0",
       "workspaces": [
         "plugins/acm",
@@ -226,6 +242,7 @@
       "version": "0.3.9",
       "resolved": "https://registry.npmjs.org/@aws-lite/dynamodb/-/dynamodb-0.3.9.tgz",
       "integrity": "sha512-jrMAWwxoAMVJ3z0/mI/GzPM5AfGmH+xzTpNIbjg3+2WdYJRqvIf8025XJdCDtS9/4x8zogdchEp3ZelXnwYyqw==",
+      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=16"
@@ -235,6 +252,7 @@
       "version": "0.3.12",
       "resolved": "https://registry.npmjs.org/@aws-lite/dynamodb-types/-/dynamodb-types-0.3.12.tgz",
       "integrity": "sha512-CIqmmIDbf2PBLdZ9NaGY0mYIkqGO3yYLZEIWyaiSJweg8Ka1dk3bn4/LktJ0pjKgKyciMqCB7FdkLmeqLCLw6w==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/client-dynamodb": "3"
@@ -247,6 +265,7 @@
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/@aws-lite/lambda/-/lambda-0.1.5.tgz",
       "integrity": "sha512-Sa6AxBQwzqGsUr2ifxcpAvFlTkoDwIQIYgcEFVQ+0qKeV9ci+ggsOOSRGBxrGEdRsnQxUsQ2x0ES/29c8crzQw==",
+      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=16"
@@ -269,6 +288,7 @@
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/@aws-lite/sns/-/sns-0.0.8.tgz",
       "integrity": "sha512-MIzHe66kLNyzPFY/DX30uN7DlVQsnBiHPYbq/7syNWuoYSG8bkWuUX2CVIuSL7Ji5jaLpQ4lf8/VQ+SiAeoIZA==",
+      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=16"
@@ -278,6 +298,7 @@
       "version": "0.0.11",
       "resolved": "https://registry.npmjs.org/@aws-lite/sns-types/-/sns-types-0.0.11.tgz",
       "integrity": "sha512-RYa+2dr8Gsq92fa6e4K72HQ84hNONftPnN21Jpq3lkTpMozIS7aJdOSphDc5UcAKt5ZrYzjfRCcHM7OOZLua9g==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/client-sns": "3"
@@ -290,6 +311,7 @@
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/@aws-lite/sqs/-/sqs-0.2.4.tgz",
       "integrity": "sha512-a1M3HDdkNE/xJfASlfisAaZ8XF6FpvoJbJsH/gr6pogEFWgNQyvmPVNRElnDY7JW3ee82sEOkMukYRdAbjytNQ==",
+      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=16"
@@ -312,6 +334,7 @@
       "version": "3.1044.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-dynamodb/-/client-dynamodb-3.1044.0.tgz",
       "integrity": "sha512-E9dZeAbyWC1YRAjdeQ7i1aK8635cQSpX4m0cUAlySiQRLux7NZa89BER07LU5OLi6ObnTi0FE7Vy0WbICUotjw==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
@@ -421,6 +444,7 @@
       "version": "3.1044.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-sns/-/client-sns-3.1044.0.tgz",
       "integrity": "sha512-0vcufJrms7t4dV9yO2N71t2Nme2mavOm51eaeXEcjMRow2DY64aIqe9pO7NE+WwMeE1RqN0tUy9mH9wRaxC2/Q==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
@@ -524,6 +548,7 @@
       "version": "3.974.8",
       "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.8.tgz",
       "integrity": "sha512-njR2qoG6ZuB0kvAS2FyICsFZJ6gmCcf2X/7JcD14sUvGDm26wiZ5BrA6LOiUxKFEF+IVe7kdroxyE00YlkiYsw==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "^3.973.8",
@@ -549,6 +574,7 @@
       "version": "3.972.34",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.34.tgz",
       "integrity": "sha512-XT0jtf8Fw9JE6ppsQeoNnZRiG+jqRixMT1v1ZR17G60UvVdsQmTG8nbEyHuEPfMxDXEhfdARaM/XiEhca4lGHQ==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/core": "^3.974.8",
@@ -565,6 +591,7 @@
       "version": "3.972.36",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.36.tgz",
       "integrity": "sha512-DPoGWfy7J7RKxvbf5kOKIGQkD2ek3dbKgzKIGrnLuvZBz5myU+Im/H6pmc14QcnFbqHMqxvtWSgRDSJW3qXLQg==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/core": "^3.974.8",
@@ -586,6 +613,7 @@
       "version": "3.972.38",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.38.tgz",
       "integrity": "sha512-oDzUBu2MGJFgoar05sPMCwSrhw44ASyccrHzj66vO69OZqi7I6hZZxXfuPLC8OCzW7C+sU+bI73XHij41yekgQ==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/core": "^3.974.8",
@@ -611,6 +639,7 @@
       "version": "3.972.38",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.38.tgz",
       "integrity": "sha512-g1NosS8qe4OF++G2UFCM5ovSkgipC7YYor5KCWatG0UoMSO5YFj9C8muePlyVmOBV/WTI16Jo3/s1NUo/o1Bww==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/core": "^3.974.8",
@@ -630,6 +659,7 @@
       "version": "3.972.39",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.39.tgz",
       "integrity": "sha512-HEswDQyxUtadoZ/bJsPPENHg7R0Lzym5LuMksJeHvqhCOpP+rtkDLKI4/ZChH4w3cf5kG8n6bZuI8PzajoiqMg==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/credential-provider-env": "^3.972.34",
@@ -653,6 +683,7 @@
       "version": "3.972.34",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.34.tgz",
       "integrity": "sha512-T3IFs4EVmVi1dVN5RciFnklCANSzvrQd/VuHY9ThHSQmYkTogjcGkoJEr+oNUPQZnso52183088NqysMPji1/Q==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/core": "^3.974.8",
@@ -670,6 +701,7 @@
       "version": "3.972.38",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.38.tgz",
       "integrity": "sha512-5ZxG+t0+3Q3QPh8KEjX6syskhgNf7I0MN7oGioTf6Lm1NTjfP7sIcYGNsthXC2qR8vcD3edNZwCr2ovfSSWuRA==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/core": "^3.974.8",
@@ -689,6 +721,7 @@
       "version": "3.972.38",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.38.tgz",
       "integrity": "sha512-lYHFF30DGI20jZcYX8cm6Ns0V7f1dDN6g/MBDLTyD/5iw+bXs3yBr2iAiHDkx4RFU5JgsnZvCHYKiRVPRdmOgw==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/core": "^3.974.8",
@@ -707,6 +740,7 @@
       "version": "3.973.8",
       "resolved": "https://registry.npmjs.org/@aws-sdk/dynamodb-codec/-/dynamodb-codec-3.973.8.tgz",
       "integrity": "sha512-dYQ/cQqHZd23hcl8oEGwPphTqyGnmvf2HrVmz4J90Q5Bv89oJjlwcBcifiiTvApqsVpx7Pr0IebMpkYwWJvZlQ==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/core": "^3.974.8",
@@ -723,6 +757,7 @@
       "version": "3.972.5",
       "resolved": "https://registry.npmjs.org/@aws-sdk/endpoint-cache/-/endpoint-cache-3.972.5.tgz",
       "integrity": "sha512-itVdge0NozgtgmtbZ25FVwWU3vGlE7x7feE/aOEJNkQfEpbkrF8Rj1QmnK+2blFfYE1xWt/iU+6/jUp/pv1+MA==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "mnemonist": "0.38.3",
@@ -736,6 +771,7 @@
       "version": "3.972.11",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint-discovery/-/middleware-endpoint-discovery-3.972.11.tgz",
       "integrity": "sha512-vXARCZVFQHdsd6qPPZyC/hh+5x2XsCYKqUQDCqnUlpGpChMpDojOOacQWdLJ+FFXKN8X3cmLOGrtgx/zysCKqQ==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/endpoint-cache": "^3.972.5",
@@ -753,6 +789,7 @@
       "version": "3.972.10",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.972.10.tgz",
       "integrity": "sha512-IJSsIMeVQ8MMCPbuh1AbltkFhLBLXn7aejzfX5YKT/VLDHn++Dcz8886tXckE+wQssyPUhaXrJhdakO2VilRhg==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "^3.973.8",
@@ -768,6 +805,7 @@
       "version": "3.972.10",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.972.10.tgz",
       "integrity": "sha512-OOuGvvz1Dm20SjZo5oEBePFqxt5nf8AwkNDSyUHvD9/bfNASmstcYxFAHUowy4n6Io7mWUZ04JURZwSBvyQanQ==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "^3.973.8",
@@ -782,6 +820,7 @@
       "version": "3.972.11",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.972.11.tgz",
       "integrity": "sha512-+zz6f79Kj9V5qFK2P+D8Ehjnw4AhphAlCAsPjUqEcInA9umtSSKMrHbSagEeOIsDNuvVrH98bjRHcyQukTrhaQ==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "^3.973.8",
@@ -798,6 +837,7 @@
       "version": "3.972.37",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.37.tgz",
       "integrity": "sha512-Km7M+i8DrLArVzrid1gfxeGhYHBd3uxvE77g0s5a52zPSVosxzQBnJ0gwWb6NIp/DOk8gsBMhi7V+cpJG0ndTA==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/core": "^3.974.8",
@@ -841,6 +881,7 @@
       "version": "3.972.38",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.972.38.tgz",
       "integrity": "sha512-iz+B29TXcAZsJpwB+AwG/TTGA5l/VnmMZ2UxtiySOZjI6gCdmviXPwdgzcmuazMy16rXoPY4mYCGe7zdNKfx5A==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/core": "^3.974.8",
@@ -860,6 +901,7 @@
       "version": "3.997.6",
       "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.6.tgz",
       "integrity": "sha512-WBDnqatJl+kGObpfmfSxqnXeYTu3Me8wx8WCtvoxX3pfWrrTv8I4WTMSSs7PZqcRcVh8WeUKMgGFjMG+52SR1w==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
@@ -910,6 +952,7 @@
       "version": "3.972.13",
       "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.13.tgz",
       "integrity": "sha512-CvJ2ZIjK/jVD/lbOpowBVElJyC1YxLTIJ13yM0AEo0t2v7swOzGjSA6lJGH+DwZXQhcjUjoYwc8bVYCX5MDr1A==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "^3.973.8",
@@ -926,6 +969,7 @@
       "version": "3.996.25",
       "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.25.tgz",
       "integrity": "sha512-+CMIt3e1VzlklAECmG+DtP1sV8iKq25FuA0OKpnJ4KA0kxUtd7CgClY7/RU6VzJBQwbN4EJ9Ue6plvqx1qGadw==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/middleware-sdk-s3": "^3.972.37",
@@ -943,6 +987,7 @@
       "version": "3.1041.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1041.0.tgz",
       "integrity": "sha512-Th7kPI6YPtvJUcdznooXJMy+9rQWjmEF81LxaJssngBzuysK4a/x+l8kjm1zb7nYsUPbndnBdUnwng/3PLvtGw==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/core": "^3.974.8",
@@ -961,6 +1006,7 @@
       "version": "3.973.8",
       "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.8.tgz",
       "integrity": "sha512-gjlAdtHMbtR9X5iIhVUvbVcy55KnznpC6bkDUWW9z915bi0ckdUr5cjf16Kp6xq0bP5HBD2xzgbL9F9Quv5vUw==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.14.1",
@@ -974,6 +1020,7 @@
       "version": "3.972.3",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.972.3.tgz",
       "integrity": "sha512-HzSD8PMFrvgi2Kserxuff5VitNq2sgf3w9qxmskKDiDTThWfVteJxuCS9JXiPIPtmCrp+7N9asfIaVhBFORllA==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -986,6 +1033,7 @@
       "version": "3.996.8",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.996.8.tgz",
       "integrity": "sha512-oOZHcRDihk5iEe5V25NVWg45b3qEA8OpHWVdU/XQh8Zj4heVPAJqWvMphQnU7LkufmUo10EpvFPZuQMiFLJK3g==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "^3.973.8",
@@ -1002,6 +1050,7 @@
       "version": "3.965.5",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.965.5.tgz",
       "integrity": "sha512-WhlJNNINQB+9qtLtZJcpQdgZw3SCDCpXdUJP7cToGwHbCWCnRckGlc6Bx/OhWwIYFNAn+FIydY8SZ0QmVu3xTQ==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -1014,6 +1063,7 @@
       "version": "3.972.10",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.972.10.tgz",
       "integrity": "sha512-FAzqXvfEssGdSIz8ejatan0bOdx1qefBWKF/gWmVBXIP1HkS7v/wjjaqrAGGKvyihrXTXW00/2/1nTJtxpXz7g==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "^3.973.8",
@@ -1026,6 +1076,7 @@
       "version": "3.973.24",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.973.24.tgz",
       "integrity": "sha512-ZWwlkjcIp7cEL8ZfTpTAPNkwx25p7xol0xlKoWVVf22+nsjwmLcHYtTPjIV1cSpmB/b6DaK4cb1fSkvCXHgRdw==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/middleware-user-agent": "^3.972.38",
@@ -1051,6 +1102,7 @@
       "version": "3.972.22",
       "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.22.tgz",
       "integrity": "sha512-PMYKKtJd70IsSG0yHrdAbxBr+ZWBKLvzFZfD3/urxgf6hXVMzuU5M+3MJ5G67RpOmLBu1fAUN65SbWuKUCOlAA==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@nodable/entities": "2.1.0",
@@ -1066,6 +1118,7 @@
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.4.tgz",
       "integrity": "sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==",
+      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18.0.0"
@@ -1782,6 +1835,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
       "integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -2193,6 +2247,7 @@
       "version": "4.4.17",
       "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.4.17.tgz",
       "integrity": "sha512-TzDZcAnhTyAHbXVxWZo7/tEcrIeFq20IBk8So3OLOetWpR8EwY/yEqBMBFaJMeyEiREDq4NfEl+qO3OAUD+vbQ==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/node-config-provider": "^4.3.14",
@@ -2210,6 +2265,7 @@
       "version": "3.23.17",
       "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.23.17.tgz",
       "integrity": "sha512-x7BlLbUFL8NWCGjMF9C+1N5cVCxcPa7g6Tv9B4A2luWx3be3oU8hQ96wIwxe/s7OhIzvoJH73HAUSg5JXVlEtQ==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/protocol-http": "^5.3.14",
@@ -2231,6 +2287,7 @@
       "version": "4.2.14",
       "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.2.14.tgz",
       "integrity": "sha512-Au28zBN48ZAoXdooGUHemuVBrkE+Ie6RPmGNIAJsFqj33Vhb6xAgRifUydZ2aY+M+KaMAETAlKk5NC5h1G7wpg==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/node-config-provider": "^4.3.14",
@@ -2322,6 +2379,7 @@
       "version": "5.3.17",
       "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.3.17.tgz",
       "integrity": "sha512-bXOvQzaSm6MnmLaWA1elgfQcAtN4UP3vXqV97bHuoOrHQOJiLT3ds6o9eo5bqd0TJfRFpzdGnDQdW3FACiAVdw==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/protocol-http": "^5.3.14",
@@ -2338,6 +2396,7 @@
       "version": "4.2.14",
       "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.2.14.tgz",
       "integrity": "sha512-8ZBDY2DD4wr+GGjTpPtiglEsqr0lUP+KHqgZcWczFf6qeZ/YRjMIOoQWVQlmwu7EtxKTd8YXD8lblmYcpBIA1g==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.14.1",
@@ -2353,6 +2412,7 @@
       "version": "4.2.14",
       "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.2.14.tgz",
       "integrity": "sha512-c21qJiTSb25xvvOp+H2TNZzPCngrvl5vIPqPB8zQ/DmJF4QWXO19x1dWfMJZ6wZuuWUPPm0gV8C0cU3+ifcWuw==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.14.1",
@@ -2366,6 +2426,7 @@
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.2.2.tgz",
       "integrity": "sha512-n6rQ4N8Jj4YTQO3YFrlgZuwKodf4zUFs7EJIWH86pSCWBaAtAGBFfCM7Wx6D2bBJ2xqFNxGBSrUWswT3M0VJow==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -2393,6 +2454,7 @@
       "version": "4.2.14",
       "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.2.14.tgz",
       "integrity": "sha512-xhHq7fX4/3lv5NHxLUk3OeEvl0xZ+Ek3qIbWaCL4f9JwgDZEclPBElljaZCAItdGPQl/kSM4LPMOpy1MYgprpw==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/protocol-http": "^5.3.14",
@@ -2407,6 +2469,7 @@
       "version": "4.4.32",
       "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.4.32.tgz",
       "integrity": "sha512-ZZkgyjnJppiZbIm6Qbx92pbXYi1uzenIvGhBSCDlc7NwuAkiqSgS75j1czAD25ZLs2FjMjYy1q7gyRVWG6JA0Q==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/core": "^3.23.17",
@@ -2426,6 +2489,7 @@
       "version": "4.5.7",
       "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.5.7.tgz",
       "integrity": "sha512-bRt6ZImqVSeTk39Nm81K20ObIiAZ3WefY7G6+iz/0tZjs4dgRRjvRX2sgsH+zi6iDCRR/aQvQofLKxxz4rPBZg==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/core": "^3.23.17",
@@ -2447,6 +2511,7 @@
       "version": "4.2.20",
       "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.2.20.tgz",
       "integrity": "sha512-Lx9JMO9vArPtiChE3wbEZ5akMIDQpWQtlu90lhACQmNOXcGXRbaDywMHDzuDZ2OkZzP+9wQfZi3YJT9F67zTQQ==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/core": "^3.23.17",
@@ -2462,6 +2527,7 @@
       "version": "4.2.14",
       "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.2.14.tgz",
       "integrity": "sha512-2dvkUKLuFdKsCRmOE4Mn63co0Djtsm+JMh0bYZQupN1pJwMeE8FmQmRLLzzEMN0dnNi7CDCYYH8F0EVwWiPBeA==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.14.1",
@@ -2475,6 +2541,7 @@
       "version": "4.3.14",
       "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.3.14.tgz",
       "integrity": "sha512-S+gFjyo/weSVL0P1b9Ts8C/CwIfNCgUPikk3sl6QVsfE/uUuO+QsF+NsE/JkpvWqqyz1wg7HFdiaZuj5CoBMRg==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/property-provider": "^4.2.14",
@@ -2490,6 +2557,7 @@
       "version": "4.6.1",
       "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.6.1.tgz",
       "integrity": "sha512-iB+orM4x3xrr57X3YaXazfKnntl0LHlZB1kcXSGzMV1Tt0+YwEjGlbjk/44qEGtBzXAz6yFDzkYTKSV6Pj2HUg==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/protocol-http": "^5.3.14",
@@ -2505,6 +2573,7 @@
       "version": "4.2.14",
       "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.2.14.tgz",
       "integrity": "sha512-WuM31CgfsnQ/10i7NYr0PyxqknD72Y5uMfUMVSniPjbEPceiTErb4eIqJQ+pdxNEAUEWrewrGjIRjVbVHsxZiQ==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.14.1",
@@ -2518,6 +2587,7 @@
       "version": "5.3.14",
       "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.14.tgz",
       "integrity": "sha512-dN5F8kHx8RNU0r+pCwNmFZyz6ChjMkzShy/zup6MtkRmmix4vZzJdW+di7x//b1LiynIev88FM18ie+wwPcQtQ==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.14.1",
@@ -2531,6 +2601,7 @@
       "version": "4.2.14",
       "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.2.14.tgz",
       "integrity": "sha512-XYA5Z0IqTeF+5XDdh4BBmSA0HvbgVZIyv4cmOoUheDNR57K1HgBp9ukUMx3Cr3XpDHHpLBnexPE3LAtDsZkj2A==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.14.1",
@@ -2545,6 +2616,7 @@
       "version": "4.2.14",
       "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.2.14.tgz",
       "integrity": "sha512-hr+YyqBD23GVvRxGGrcc/oOeNlK3PzT5Fu4dzrDXxzS1LpFiuL2PQQqKPs87M79aW7ziMs+nvB3qdw77SqE7Lw==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.14.1",
@@ -2558,6 +2630,7 @@
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.3.1.tgz",
       "integrity": "sha512-aUQuDGh760ts/8MU+APjIZhlLPKhIIfqyzZaJikLEIMrdxFvxuLYD0WxWzaYWpmLbQlXDe9p7EWM3HsBe0K6Gw==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.14.1"
@@ -2570,6 +2643,7 @@
       "version": "4.4.9",
       "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.4.9.tgz",
       "integrity": "sha512-495/V2I15SHgedSJoDPD23JuSfKAp726ZI1V0wtjB07Wh7q/0tri/0e0DLefZCHgxZonrGKt/OCTpAtP1wE1kQ==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.14.1",
@@ -2583,6 +2657,7 @@
       "version": "5.3.14",
       "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.3.14.tgz",
       "integrity": "sha512-1D9Y/nmlVjCeSivCbhZ7hgEpmHyY1h0GvpSZt3l0xcD9JjmjVC1CHOozS6+Gh+/ldMH8JuJ6cujObQqfayAVFA==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/is-array-buffer": "^4.2.2",
@@ -2602,6 +2677,7 @@
       "version": "4.12.13",
       "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.12.13.tgz",
       "integrity": "sha512-y/Pcj1V9+qG98gyu1gvftHB7rDpdh+7kIBIggs55yGm3JdtBV8GT8IFF3a1qxZ79QnaJHX9GXzvBG6tAd+czJA==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/core": "^3.23.17",
@@ -2620,6 +2696,7 @@
       "version": "4.14.1",
       "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.1.tgz",
       "integrity": "sha512-59b5HtSVrVR/eYNei3BUj3DCPKD/G7EtDDe7OEJE7i7FtQFugYo6MxbotS8mVJkLNVf8gYaAlEBwwtJ9HzhWSg==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -2632,6 +2709,7 @@
       "version": "4.2.14",
       "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.2.14.tgz",
       "integrity": "sha512-p06BiBigJ8bTA3MgnOfCtDUWnAMY0YfedO/GRpmc7p+wg3KW8vbXy1xwSu5ASy0wV7rRYtlfZOIKH4XqfhjSQQ==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/querystring-parser": "^4.2.14",
@@ -2646,6 +2724,7 @@
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-4.3.2.tgz",
       "integrity": "sha512-XRH6b0H/5A3SgblmMa5ErXQ2XKhfbQB+Fm/oyLZ2O2kCUrwgg55bU0RekmzAhuwOjA9qdN5VU2BprOvGGUkOOQ==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/util-buffer-from": "^4.2.2",
@@ -2660,6 +2739,7 @@
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-4.2.2.tgz",
       "integrity": "sha512-JKCrLNOup3OOgmzeaKQwi4ZCTWlYR5H4Gm1r2uTMVBXoemo1UEghk5vtMi1xSu2ymgKVGW631e2fp9/R610ZjQ==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -2672,6 +2752,7 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-4.2.3.tgz",
       "integrity": "sha512-ZkJGvqBzMHVHE7r/hcuCxlTY8pQr1kMtdsVPs7ex4mMU+EAbcXppfo5NmyxMYi2XU49eqaz56j2gsk4dHHPG/g==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -2684,6 +2765,7 @@
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.2.2.tgz",
       "integrity": "sha512-FDXD7cvUoFWwN6vtQfEta540Y/YBe5JneK3SoZg9bThSoOAC/eGeYEua6RkBgKjGa/sz6Y+DuBZj3+YEY21y4Q==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/is-array-buffer": "^4.2.2",
@@ -2697,6 +2779,7 @@
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-4.2.2.tgz",
       "integrity": "sha512-dWU03V3XUprJwaUIFVv4iOnS1FC9HnMHDfUrlNDSh4315v0cWyaIErP8KiqGVbf5z+JupoVpNM7ZB3jFiTejvQ==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -2709,6 +2792,7 @@
       "version": "4.3.49",
       "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.3.49.tgz",
       "integrity": "sha512-a5bNrdiONYB/qE2BuKegvUMd/+ZDwdg4vsNuuSzYE8qs2EYAdK9CynL+Rzn29PbPiUqoz/cbpRbcLzD5lEevHw==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/property-provider": "^4.2.14",
@@ -2724,6 +2808,7 @@
       "version": "4.2.54",
       "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.2.54.tgz",
       "integrity": "sha512-g1cvrJvOnzeJgEdf7AE4luI7gp6L8weE0y9a9wQUSGtjb8QRHDbCJYuE4Sy0SD9N8RrnNPFsPltAz/OSoBR9Zw==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/config-resolver": "^4.4.17",
@@ -2742,6 +2827,7 @@
       "version": "3.4.2",
       "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.4.2.tgz",
       "integrity": "sha512-a55Tr+3OKld4TTtnT+RhKOQHyPxm3j/xL4OR83WBUhLJaKDS9dnJ7arRMOp3t31dcLhApwG9bgvrRXBHlLdIkg==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/node-config-provider": "^4.3.14",
@@ -2756,6 +2842,7 @@
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-4.2.2.tgz",
       "integrity": "sha512-Qcz3W5vuHK4sLQdyT93k/rfrUwdJ8/HZ+nMUOyGdpeGA1Wxt65zYwi3oEl9kOM+RswvYq90fzkNDahPS8K0OIg==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -2768,6 +2855,7 @@
       "version": "4.2.14",
       "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.14.tgz",
       "integrity": "sha512-1Su2vj9RYNDEv/V+2E+jXkkwGsgR7dc4sfHn9Z7ruzQHJIEni9zzw5CauvRXlFJfmgcqYP8fWa0dkh2Q2YaQyw==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.14.1",
@@ -2781,6 +2869,7 @@
       "version": "4.3.8",
       "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.3.8.tgz",
       "integrity": "sha512-LUIxbTBi+OpvXpg91poGA6BdyoleMDLnfXjVDqyi2RvZmTveY5loE/FgYUBCR5LU2BThW2SoZRh8dTIIy38IPw==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/service-error-classification": "^4.3.1",
@@ -2795,6 +2884,7 @@
       "version": "4.5.25",
       "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.5.25.tgz",
       "integrity": "sha512-/PFpG4k8Ze8Ei+mMKj3oiPICYekthuzePZMgZbCqMiXIHHf4n2aZ4Ps0aSRShycFTGuj/J6XldmC0x0DwednIA==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/fetch-http-handler": "^5.3.17",
@@ -2814,6 +2904,7 @@
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.2.2.tgz",
       "integrity": "sha512-2kAStBlvq+lTXHyAZYfJRb/DfS3rsinLiwb+69SstC9Vb0s9vNWkRwpnj918Pfi85mzi42sOqdV72OLxWAISnw==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -2826,6 +2917,7 @@
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.2.tgz",
       "integrity": "sha512-75MeYpjdWRe8M5E3AW0O4Cx3UadweS+cwdXjwYGBW5h/gxxnbeZ877sLPX/ZJA9GVTlL/qG0dXP29JWFCD1Ayw==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/util-buffer-from": "^4.2.2",
@@ -2839,6 +2931,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-4.3.0.tgz",
       "integrity": "sha512-JyjYmLAfS+pdxF92o4yLgEoy0zhayKTw73FU1aofLWwLcJw7iSqIY2exGmMTrl/lmZugP5p/zxdFSippJDfKWA==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.14.1",
@@ -2852,6 +2945,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@smithy/uuid/-/uuid-1.1.2.tgz",
       "integrity": "sha512-O/IEdcCUKkubz60tFbGA7ceITTAJsty+lBjNoorP4Z6XRqaFb/OjQjZODophEcuq68nKm6/0r+6/lLQ+XVpk8g==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -2908,6 +3002,7 @@
       "integrity": "sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -3094,6 +3189,7 @@
       "version": "1.13.2",
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.13.2.tgz",
       "integrity": "sha512-lHe62zvbTB5eEABUVi/AwVh0ZKY9rMMDhmm+eeyuuUQbQ3+J+fONVQOZyj+DdrvD4BY33uYniyRJ4UJIaSKAfw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/balanced-match": {
@@ -3110,6 +3206,7 @@
       "version": "2.14.1",
       "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
       "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
@@ -3221,6 +3318,7 @@
       "version": "1.1.9",
       "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.9.tgz",
       "integrity": "sha512-jcyKVSEX13iseJqg7n/KWw+xnu/7fdrZ333Fac54KjHDIELVCfDDJXYIm6DTJ0Su4gSzrhqiK0DzY/wZbF40mw==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -3236,6 +3334,7 @@
       "version": "5.7.2",
       "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.2.tgz",
       "integrity": "sha512-P7oW7tLbYnhOLQk/Gv7cZgzgMPP/XN03K02/Jy6Y/NHzyIAIpxuZIM/YqAkfiXFPxA2CTm7NtCijK9EDu09u2w==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -3487,6 +3586,7 @@
       "version": "0.38.3",
       "resolved": "https://registry.npmjs.org/mnemonist/-/mnemonist-0.38.3.tgz",
       "integrity": "sha512-2K9QYubXx/NAjv4VLq1d1Ly8pWNC5L3BrixtdkyTegXWJIqY+zLNDhhX/A+ZwWt70tB1S8H4BE8FLYEFyNoOBw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "obliterator": "^1.6.1"
@@ -3515,6 +3615,7 @@
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/obliterator/-/obliterator-1.6.1.tgz",
       "integrity": "sha512-9WXswnqINnnhOG/5SLimUlzuU1hFJUc8zkwyD59Sd+dPOMf05PmnYG/d6Q7HZ+KmgkZJa1PxRso6QdM3sTNHig==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/obug": {
@@ -3539,6 +3640,7 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
       "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -3587,6 +3689,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3746,6 +3849,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.3.0.tgz",
       "integrity": "sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -3815,6 +3919,7 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
       "license": "0BSD"
     },
     "node_modules/typedoc": {
@@ -3847,6 +3952,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -3875,6 +3981,7 @@
       "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -3950,6 +4057,7 @@
       "integrity": "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.0.18",
         "@vitest/mocker": "4.0.18",

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "@aws-lite/sqs": "^0.2.4",
         "@aws-lite/sqs-types": "^0.2.7",
         "@biomejs/biome": "2.3.12",
-        "@types/node": "^20.19.39",
+        "@types/node": "^20.19.43",
         "@vitest/coverage-v8": "^4.0.18",
         "rimraf": "^6.1.2",
         "typedoc": "^0.28.16",
@@ -2997,9 +2997,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "20.19.39",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.39.tgz",
-      "integrity": "sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==",
+      "version": "20.19.43",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.43.tgz",
+      "integrity": "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==",
       "dev": true,
       "license": "MIT",
       "peer": true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "@aws-lite/sqs": "^0.2.4",
         "@aws-lite/sqs-types": "^0.2.7",
         "@biomejs/biome": "2.3.12",
-        "@types/node": "^20.19.43",
+        "@types/node": "^22",
         "@vitest/coverage-v8": "^4.0.18",
         "rimraf": "^6.1.2",
         "typedoc": "^0.28.16",
@@ -27,7 +27,7 @@
         "vitest": "4.0.18"
       },
       "engines": {
-        "node": ">=20.19"
+        "node": ">=22"
       },
       "peerDependencies": {
         "@aws-lite/client": "^0.23.6",
@@ -2997,9 +2997,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "20.19.43",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.43.tgz",
-      "integrity": "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==",
+      "version": "22.19.21",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.21.tgz",
+      "integrity": "sha512-VMeFBSCKQKmm2swI2kW51SFusDqekC6q9trBCvJ/JliDchFSuoYYKN7yVNjPthP1HKZcx3U1gI/wTcEBjEFKTA==",
       "dev": true,
       "license": "MIT",
       "peer": true,

--- a/package.json
+++ b/package.json
@@ -47,8 +47,12 @@
     "typecheck": "tsc --noEmit --project tsconfig.test.json"
   },
   "devDependencies": {
+    "@aws-lite/dynamodb-types": "^0.3.12",
+    "@aws-lite/lambda-types": "^0.1.6",
+    "@aws-lite/sns-types": "^0.0.11",
+    "@aws-lite/sqs-types": "^0.2.7",
     "@biomejs/biome": "2.3.12",
-    "@types/node": "^20",
+    "@types/node": "^20.19.39",
     "@vitest/coverage-v8": "^4.0.18",
     "rimraf": "^6.1.2",
     "typedoc": "^0.28.16",
@@ -60,5 +64,12 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "dependencies": {
+    "@aws-lite/client": "^0.23.6",
+    "@aws-lite/dynamodb": "^0.3.9",
+    "@aws-lite/lambda": "^0.1.5",
+    "@aws-lite/sns": "^0.0.8",
+    "@aws-lite/sqs": "^0.2.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -47,9 +47,14 @@
     "typecheck": "tsc --noEmit --project tsconfig.test.json"
   },
   "devDependencies": {
+    "@aws-lite/client": "^0.23.6",
+    "@aws-lite/dynamodb": "^0.3.9",
     "@aws-lite/dynamodb-types": "^0.3.12",
+    "@aws-lite/lambda": "^0.1.5",
     "@aws-lite/lambda-types": "^0.1.6",
+    "@aws-lite/sns": "^0.0.8",
     "@aws-lite/sns-types": "^0.0.11",
+    "@aws-lite/sqs": "^0.2.4",
     "@aws-lite/sqs-types": "^0.2.7",
     "@biomejs/biome": "2.3.12",
     "@types/node": "^20.19.39",
@@ -65,7 +70,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "dependencies": {
+  "peerDependencies": {
     "@aws-lite/client": "^0.23.6",
     "@aws-lite/dynamodb": "^0.3.9",
     "@aws-lite/lambda": "^0.1.5",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "@aws-lite/sqs": "^0.2.4",
     "@aws-lite/sqs-types": "^0.2.7",
     "@biomejs/biome": "2.3.12",
-    "@types/node": "^20.19.39",
+    "@types/node": "^22",
     "@vitest/coverage-v8": "^4.0.18",
     "rimraf": "^6.1.2",
     "typedoc": "^0.28.16",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "vitest": "4.0.18"
   },
   "engines": {
-    "node": ">=20.19"
+    "node": ">=22"
   },
   "publishConfig": {
     "access": "public"

--- a/src/aws-lite-plugins.d.ts
+++ b/src/aws-lite-plugins.d.ts
@@ -1,0 +1,4 @@
+declare module '@aws-lite/dynamodb'
+declare module '@aws-lite/lambda'
+declare module '@aws-lite/sns'
+declare module '@aws-lite/sqs'

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,3 @@
 export * from './definers.js'
+export * from './invoke/index.js'
 export * from './types.js'

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,3 @@
 export * from './definers.js'
-export * from './invoke/index.js'
+export * from './invoke.js'
 export * from './types.js'

--- a/src/invoke.ts
+++ b/src/invoke.ts
@@ -16,10 +16,14 @@ function getAwsLite() {
   if (!awsPromise) {
     awsPromise = awsLite({
       plugins: [import('@aws-lite/dynamodb'), import('@aws-lite/lambda'), import('@aws-lite/sns'), import('@aws-lite/sqs')],
+    }).catch((err) => {
+      awsPromise = undefined
+      throw err
     })
   }
   return awsPromise
 }
+
 /**
  * Gets a specific resource based off of function name
  * @param {string} name
@@ -44,14 +48,14 @@ async function getResource(name: string, aws: awsLite.AwsLiteClient): Promise<Fu
 export async function invoke(name: string, payload: FunctionPayload) {
   if (!name) throw new Error('Function name was not provided')
 
-  const aws = await getAwsLite()
-  if (!aws) throw new Error(`Unable to invoke function: ${name}`)
-
   const stringPayload = JSON.stringify(payload)
   // Check to make sure payload is not over the max we can handle
   if (Buffer.byteLength(stringPayload, 'utf8') > MAX_EVENT_SIZE_BYTES) {
     throw new Error(`Payload exceeds maximum size of ${MAX_EVENT_SIZE_BYTES / 1024}KB`)
   }
+
+  const aws = await getAwsLite()
+  if (!aws) throw new Error(`Unable to invoke function: ${name}`)
 
   // Look up the function details
   const resource = await getResource(name, aws)

--- a/src/invoke.ts
+++ b/src/invoke.ts
@@ -53,7 +53,6 @@ export async function invoke(name: string, payload: FunctionPayload) {
     await aws.SQS.SendMessage({
       MessageBody: stringPayload,
       QueueUrl: resource.queue.physicalResourceId,
-      MessageGroupId: name,
     })
   } else if (resource.function) {
     await aws.Lambda.Invoke({

--- a/src/invoke.ts
+++ b/src/invoke.ts
@@ -5,17 +5,26 @@ import type {FunctionPayload, FunctionResourceEnvelope} from './types.js'
 
 const MAX_EVENT_SIZE_BYTES = 256 * 1024
 
-const aws = await awsLite({
-  plugins: [import('@aws-lite/dynamodb'), import('@aws-lite/lambda'), import('@aws-lite/sns'), import('@aws-lite/sqs')],
-})
+let awsPromise: ReturnType<typeof awsLite> | undefined
 
 const PARTITION_KEY = 'arc-app-res'
 
 /**
+ * lazy load aws-lite
+ */
+function getAwsLite() {
+  if (!awsPromise) {
+    awsPromise = awsLite({
+      plugins: [import('@aws-lite/dynamodb'), import('@aws-lite/lambda'), import('@aws-lite/sns'), import('@aws-lite/sqs')],
+    })
+  }
+  return awsPromise
+}
+/**
  * Gets a specific resource based off of function name
  * @param {string} name
  */
-async function getResource(name: string): Promise<FunctionResourceEnvelope> {
+async function getResource(name: string, aws: awsLite.AwsLiteClient): Promise<FunctionResourceEnvelope> {
   const TableName = env['SANITY_DISCO']
   if (!TableName) throw new Error('SANITY_DISCO env var not set')
 
@@ -34,14 +43,17 @@ async function getResource(name: string): Promise<FunctionResourceEnvelope> {
 export async function invoke(name: string, payload: FunctionPayload) {
   if (!name) throw new Error('Function name was not provided')
 
+  const aws = await getAwsLite()
+  if (!aws) throw new Error(`Unable to invoke function: ${name}`)
+
   const stringPayload = JSON.stringify(payload)
   // Check to make sure payload is not over the max we can handle
   if (Buffer.byteLength(stringPayload, 'utf8') > MAX_EVENT_SIZE_BYTES) {
-    throw new Error(`Event exceeds maximum size of 256KB`)
+    throw new Error(`Payload exceeds maximum size of ${MAX_EVENT_SIZE_BYTES / 1024}KB`)
   }
 
   // Look up the function details
-  const resource = await getResource(name)
+  const resource = await getResource(name, aws)
 
   // Determine which method to invoke the function
   if (resource.topic) {

--- a/src/invoke.ts
+++ b/src/invoke.ts
@@ -1,11 +1,11 @@
 import {Buffer} from 'node:buffer'
 import {env} from 'node:process'
-import awsLite from '@aws-lite/client'
+import type awsLite from '@aws-lite/client'
 import type {FunctionPayload, FunctionResourceEnvelope} from './types.js'
 
 const MAX_EVENT_SIZE_BYTES = 256 * 1024
 
-let awsPromise: ReturnType<typeof awsLite> | undefined
+let awsPromise: Promise<awsLite.AwsLiteClient> | undefined
 
 const PARTITION_KEY = 'arc-app-res'
 
@@ -14,9 +14,12 @@ const PARTITION_KEY = 'arc-app-res'
  */
 function getAwsLite() {
   if (!awsPromise) {
-    awsPromise = awsLite({
-      plugins: [import('@aws-lite/dynamodb'), import('@aws-lite/lambda'), import('@aws-lite/sns'), import('@aws-lite/sqs')],
-    }).catch((err) => {
+    awsPromise = (async () => {
+      const {default: awsLite} = await import('@aws-lite/client')
+      return awsLite({
+        plugins: [import('@aws-lite/dynamodb'), import('@aws-lite/lambda'), import('@aws-lite/sns'), import('@aws-lite/sqs')],
+      })
+    })().catch((err) => {
       awsPromise = undefined
       throw err
     })

--- a/src/invoke.ts
+++ b/src/invoke.ts
@@ -1,7 +1,7 @@
 import {Buffer} from 'node:buffer'
 import {env} from 'node:process'
 import awsLite from '@aws-lite/client'
-import type {FunctionPayload, FunctionResourceEnvelope} from '../types.js'
+import type {FunctionPayload, FunctionResourceEnvelope} from './types.js'
 
 const MAX_EVENT_SIZE_BYTES = 256 * 1024
 
@@ -45,25 +45,22 @@ export async function invoke(name: string, payload: FunctionPayload) {
 
   // Determine which method to invoke the function
   if (resource.topic) {
-    console.log('publishing a topic')
     await aws.SNS.Publish({
       TopicArn: resource.topic.physicalResourceId,
       Message: stringPayload,
     })
   } else if (resource.queue) {
-    console.log('sending a message')
     await aws.SQS.SendMessage({
       MessageBody: stringPayload,
       QueueUrl: resource.queue.physicalResourceId,
       MessageGroupId: name,
     })
   } else if (resource.function) {
-    console.log('calling a function')
     await aws.Lambda.Invoke({
       FunctionName: resource.function.physicalResourceId,
       Payload: {payload},
     })
   } else {
-    throw new Error(`No dispatchable resource for function: ${name}`)
+    throw new Error(`No invokeable resource for function: ${name}`)
   }
 }

--- a/src/invoke.ts
+++ b/src/invoke.ts
@@ -37,6 +37,7 @@ async function getResource(name: string, aws: awsLite.AwsLiteClient): Promise<Fu
     ProjectionExpression: 'resources',
   })
   if (!result?.Item) throw new Error(`Function not found: ${name}`)
+  if (!result.Item['resources']) throw new Error(`Resource record for ${name} is missing resources`)
   return result.Item['resources'] as unknown as FunctionResourceEnvelope
 }
 

--- a/src/invoke.ts
+++ b/src/invoke.ts
@@ -69,7 +69,8 @@ export async function invoke(name: string, payload: FunctionPayload) {
   } else if (resource.function) {
     await aws.Lambda.Invoke({
       FunctionName: resource.function.physicalResourceId,
-      Payload: {payload},
+      Payload: payload,
+      InvocationType: 'Event',
     })
   } else {
     throw new Error(`No invokeable resource for function: ${name}`)

--- a/src/invoke/index.ts
+++ b/src/invoke/index.ts
@@ -1,7 +1,7 @@
 import {Buffer} from 'node:buffer'
 import {env} from 'node:process'
 import awsLite from '@aws-lite/client'
-import type {FunctionInvokeParameters, FunctionResourceEnvelope} from '../types.js'
+import type {FunctionPayload, FunctionResourceEnvelope} from '../types.js'
 
 const MAX_EVENT_SIZE_BYTES = 256 * 1024
 
@@ -18,7 +18,6 @@ const PARTITION_KEY = 'arc-app-res'
 async function getResource(name: string): Promise<FunctionResourceEnvelope> {
   const TableName = env['SANITY_DISCO']
   if (!TableName) throw new Error('SANITY_DISCO env var not set')
-  if (!name) throw new Error('Function name was not provided')
 
   const result = await aws.DynamoDB.GetItem({
     TableName,
@@ -32,24 +31,29 @@ async function getResource(name: string): Promise<FunctionResourceEnvelope> {
   return result.Item['resources'] as FunctionResourceEnvelope
 }
 
-export async function invoke({name, event}: FunctionInvokeParameters) {
-  const payload = JSON.stringify(event)
-  if (Buffer.byteLength(payload, 'utf8') > MAX_EVENT_SIZE_BYTES) {
+export async function invoke(name: string, payload: FunctionPayload) {
+  if (!name) throw new Error('Function name was not provided')
+
+  const stringPayload = JSON.stringify(payload)
+  // Check to make sure payload is not over the max we can handle
+  if (Buffer.byteLength(stringPayload, 'utf8') > MAX_EVENT_SIZE_BYTES) {
     throw new Error(`Event exceeds maximum size of 256KB`)
   }
 
+  // Look up the function details
   const resource = await getResource(name)
 
+  // Determine which method to invoke the function
   if (resource.topic) {
     console.log('publishing a topic')
     await aws.SNS.Publish({
       TopicArn: resource.topic.physicalResourceId,
-      Message: payload,
+      Message: stringPayload,
     })
   } else if (resource.queue) {
     console.log('sending a message')
     await aws.SQS.SendMessage({
-      MessageBody: payload,
+      MessageBody: stringPayload,
       QueueUrl: resource.queue.physicalResourceId,
       MessageGroupId: name,
     })
@@ -57,7 +61,7 @@ export async function invoke({name, event}: FunctionInvokeParameters) {
     console.log('calling a function')
     await aws.Lambda.Invoke({
       FunctionName: resource.function.physicalResourceId,
-      Payload: {event},
+      Payload: {payload},
     })
   } else {
     throw new Error(`No dispatchable resource for function: ${name}`)

--- a/src/invoke/index.ts
+++ b/src/invoke/index.ts
@@ -28,7 +28,7 @@ async function getResource(name: string): Promise<FunctionResourceEnvelope> {
     ProjectionExpression: 'resources',
   })
   if (!result?.Item) throw new Error(`Function not found: ${name}`)
-  return result.Item['resources'] as FunctionResourceEnvelope
+  return result.Item['resources'] as unknown as FunctionResourceEnvelope
 }
 
 export async function invoke(name: string, payload: FunctionPayload) {

--- a/src/invoke/index.ts
+++ b/src/invoke/index.ts
@@ -1,0 +1,57 @@
+import { env } from 'node:process'
+import awsLite from '@aws-lite/client'
+import type { FunctionInvokeParameters, FunctionResourceEnvelope } from '../types.js'
+
+const aws = await awsLite({
+    plugins: [import('@aws-lite/dynamodb'), import('@aws-lite/lambda'), import('@aws-lite/sns'), import('@aws-lite/sqs')],
+})
+
+const PARTITION_KEY = 'arc-app-res'
+
+/**
+ * Gets a specific resource based off of function name
+ * @param {string} name
+ */
+async function getResource(name: string): Promise<FunctionResourceEnvelope> {
+    const TableName = env['SANITY_DISCO']
+    if (!TableName) throw new Error('SANITY_DISCO env var not set')
+    if (!name) throw new Error('Function name was not provided')
+
+    const result = await aws.DynamoDB.GetItem({
+        TableName,
+        Key: {
+            PK: PARTITION_KEY,
+            SK: name,
+        },
+        ProjectionExpression: 'resources',
+    })
+    return (result?.Item?.['resources'] as FunctionResourceEnvelope | undefined) ?? {}
+
+}
+
+export async function invoke({ name, event }: FunctionInvokeParameters) {
+    const resource = await getResource(name)
+
+    console.log(resource)
+
+    if (resource.topic) {
+        console.log('publishing a topic')
+        await aws.SNS.Publish({
+            TopicArn: resource.topic.physicalResourceId,
+            Message: JSON.stringify(event),
+        })
+    } else if (resource.queue) {
+        console.log('sending a message')
+        await aws.SQS.SendMessage({
+            MessageBody: JSON.stringify(event),
+            QueueUrl: resource.queue.physicalResourceId,
+            MessageGroupId: name,
+        })
+    } else if (resource.function) {
+        console.log('calling a function')
+        await aws.Lambda.Invoke({
+            FunctionName: resource.function.physicalResourceId,
+            Payload: { event },
+        })
+    }
+}

--- a/src/invoke/index.ts
+++ b/src/invoke/index.ts
@@ -1,9 +1,12 @@
-import { env } from 'node:process'
+import {Buffer} from 'node:buffer'
+import {env} from 'node:process'
 import awsLite from '@aws-lite/client'
-import type { FunctionInvokeParameters, FunctionResourceEnvelope } from '../types.js'
+import type {FunctionInvokeParameters, FunctionResourceEnvelope} from '../types.js'
+
+const MAX_EVENT_SIZE_BYTES = 256 * 1024
 
 const aws = await awsLite({
-    plugins: [import('@aws-lite/dynamodb'), import('@aws-lite/lambda'), import('@aws-lite/sns'), import('@aws-lite/sqs')],
+  plugins: [import('@aws-lite/dynamodb'), import('@aws-lite/lambda'), import('@aws-lite/sns'), import('@aws-lite/sqs')],
 })
 
 const PARTITION_KEY = 'arc-app-res'
@@ -13,45 +16,50 @@ const PARTITION_KEY = 'arc-app-res'
  * @param {string} name
  */
 async function getResource(name: string): Promise<FunctionResourceEnvelope> {
-    const TableName = env['SANITY_DISCO']
-    if (!TableName) throw new Error('SANITY_DISCO env var not set')
-    if (!name) throw new Error('Function name was not provided')
+  const TableName = env['SANITY_DISCO']
+  if (!TableName) throw new Error('SANITY_DISCO env var not set')
+  if (!name) throw new Error('Function name was not provided')
 
-    const result = await aws.DynamoDB.GetItem({
-        TableName,
-        Key: {
-            PK: PARTITION_KEY,
-            SK: name,
-        },
-        ProjectionExpression: 'resources',
-    })
-    if (!result?.Item) throw new Error(`Function not found: ${name}`)
-    return result.Item['resources'] as FunctionResourceEnvelope
+  const result = await aws.DynamoDB.GetItem({
+    TableName,
+    Key: {
+      PK: PARTITION_KEY,
+      SK: name,
+    },
+    ProjectionExpression: 'resources',
+  })
+  if (!result?.Item) throw new Error(`Function not found: ${name}`)
+  return result.Item['resources'] as FunctionResourceEnvelope
 }
 
-export async function invoke({ name, event }: FunctionInvokeParameters) {
-    const resource = await getResource(name)
+export async function invoke({name, event}: FunctionInvokeParameters) {
+  const payload = JSON.stringify(event)
+  if (Buffer.byteLength(payload, 'utf8') > MAX_EVENT_SIZE_BYTES) {
+    throw new Error(`Event exceeds maximum size of 256KB`)
+  }
 
-    if (resource.topic) {
-        console.log('publishing a topic')
-        await aws.SNS.Publish({
-            TopicArn: resource.topic.physicalResourceId,
-            Message: JSON.stringify(event),
-        })
-    } else if (resource.queue) {
-        console.log('sending a message')
-        await aws.SQS.SendMessage({
-            MessageBody: JSON.stringify(event),
-            QueueUrl: resource.queue.physicalResourceId,
-            MessageGroupId: name,
-        })
-    } else if (resource.function) {
-        console.log('calling a function')
-        await aws.Lambda.Invoke({
-            FunctionName: resource.function.physicalResourceId,
-            Payload: { event },
-        })
-    } else {
-        throw new Error(`No dispatchable resource for function: ${name}`)
-    }
+  const resource = await getResource(name)
+
+  if (resource.topic) {
+    console.log('publishing a topic')
+    await aws.SNS.Publish({
+      TopicArn: resource.topic.physicalResourceId,
+      Message: payload,
+    })
+  } else if (resource.queue) {
+    console.log('sending a message')
+    await aws.SQS.SendMessage({
+      MessageBody: payload,
+      QueueUrl: resource.queue.physicalResourceId,
+      MessageGroupId: name,
+    })
+  } else if (resource.function) {
+    console.log('calling a function')
+    await aws.Lambda.Invoke({
+      FunctionName: resource.function.physicalResourceId,
+      Payload: {event},
+    })
+  } else {
+    throw new Error(`No dispatchable resource for function: ${name}`)
+  }
 }

--- a/src/invoke/index.ts
+++ b/src/invoke/index.ts
@@ -25,14 +25,12 @@ async function getResource(name: string): Promise<FunctionResourceEnvelope> {
         },
         ProjectionExpression: 'resources',
     })
-    return (result?.Item?.['resources'] as FunctionResourceEnvelope | undefined) ?? {}
-
+    if (!result?.Item) throw new Error(`Function not found: ${name}`)
+    return result.Item['resources'] as FunctionResourceEnvelope
 }
 
 export async function invoke({ name, event }: FunctionInvokeParameters) {
     const resource = await getResource(name)
-
-    console.log(resource)
 
     if (resource.topic) {
         console.log('publishing a topic')
@@ -53,5 +51,7 @@ export async function invoke({ name, event }: FunctionInvokeParameters) {
             FunctionName: resource.function.physicalResourceId,
             Payload: { event },
         })
+    } else {
+        throw new Error(`No dispatchable resource for function: ${name}`)
     }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -133,6 +133,8 @@ export interface SyncTagInvalidateContext extends Omit<FunctionContext, 'clientO
      */
     token?: string
   }
+  /** Resource interface that allows access to Blueprint Resources */
+  resources: ResourcesApi
 }
 /**
  * A function handler for a sync-tag-invalidate event.

--- a/src/types.ts
+++ b/src/types.ts
@@ -103,12 +103,12 @@ export interface SyncTagInvalidateEvent {
 /**
  * A function handler for a document event.
  */
-export type DocumentEventHandler<IData = any> = (envelope: { context: FunctionContext; event: DocumentEvent<IData> }) => void | Promise<void>
+export type DocumentEventHandler<IData = any> = (envelope: {context: FunctionContext; event: DocumentEvent<IData>}) => void | Promise<void>
 
 /**
  * A function handler for a schedule event.
  */
-export type ScheduledEventHandler = (envelope: { context: ScheduledFunctionContext }) => void | Promise<void>
+export type ScheduledEventHandler = (envelope: {context: ScheduledFunctionContext}) => void | Promise<void>
 
 /**
  * A callback function to invoke once a sync-tag-invalidate event has been processed. Signals to Sanity that sync tag invalidation has completed.
@@ -165,10 +165,13 @@ export interface ResourcesApi {
   project(name: string): BlueprintResource | undefined
   role(name: string): BlueprintResource | undefined
   webhook(name: string): BlueprintResource | undefined
- *
+}
+
+/**
+ * The payload for the `invoke` method
  */
 export type FunctionPayload = {
-  event: Record<string, unknown>
+  event: DocumentEvent
   context: FunctionContext | ScheduledFunctionContext | SyncTagInvalidateContext
 }
 
@@ -180,12 +183,8 @@ export type FunctionResource = {
   physicalResourceId: string
 }
 
+type FunctionResourceKey = 'eventsourcemapping' | 'function' | 'parameter' | 'queue' | 'schedule' | 'subscription' | 'topic'
+
 export type FunctionResourceEnvelope = {
-  eventsourcemapping?: FunctionResource
-  function?: FunctionResource
-  parameter?: FunctionResource
-  queue?: FunctionResource
-  schedule?: FunctionResource
-  subscription?: FunctionResource
-  topic?: FunctionResource
-}
+  [K in FunctionResourceKey]-?: {[P in K]: FunctionResource} & {[P in Exclude<FunctionResourceKey, K>]?: FunctionResource}
+}[FunctionResourceKey]

--- a/src/types.ts
+++ b/src/types.ts
@@ -103,12 +103,12 @@ export interface SyncTagInvalidateEvent {
 /**
  * A function handler for a document event.
  */
-export type DocumentEventHandler<IData = any> = (envelope: {context: FunctionContext; event: DocumentEvent<IData>}) => void | Promise<void>
+export type DocumentEventHandler<IData = any> = (envelope: { context: FunctionContext; event: DocumentEvent<IData> }) => void | Promise<void>
 
 /**
  * A function handler for a schedule event.
  */
-export type ScheduledEventHandler = (envelope: {context: ScheduledFunctionContext}) => void | Promise<void>
+export type ScheduledEventHandler = (envelope: { context: ScheduledFunctionContext }) => void | Promise<void>
 
 /**
  * A callback function to invoke once a sync-tag-invalidate event has been processed. Signals to Sanity that sync tag invalidation has completed.
@@ -165,4 +165,24 @@ export interface ResourcesApi {
   project(name: string): BlueprintResource | undefined
   role(name: string): BlueprintResource | undefined
   webhook(name: string): BlueprintResource | undefined
+ *
+ */
+export type FunctionInvokeParameters = {
+  name: string
+  event: Record<string, unknown>
+}
+
+export type FunctionResource = {
+  logicalResourceId: string
+  physicalResourceId: string
+}
+
+export type FunctionResourceEnvelope = {
+  eventsourcemapping?: FunctionResource
+  function?: FunctionResource
+  parameter?: FunctionResource
+  queue?: FunctionResource
+  schedule?: FunctionResource
+  subscription?: FunctionResource
+  topic?: FunctionResource
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -167,9 +167,9 @@ export interface ResourcesApi {
   webhook(name: string): BlueprintResource | undefined
  *
  */
-export type FunctionInvokeParameters = {
-  name: string
+export type FunctionPayload = {
   event: Record<string, unknown>
+  context: FunctionContext | ScheduledFunctionContext | SyncTagInvalidateContext
 }
 
 export type FunctionResource = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -172,6 +172,9 @@ export type FunctionPayload = {
   context: FunctionContext | ScheduledFunctionContext | SyncTagInvalidateContext
 }
 
+/**
+ * The definition of a function resource in our resource discovery table
+ */
 export type FunctionResource = {
   logicalResourceId: string
   physicalResourceId: string

--- a/test/invoke.test.ts
+++ b/test/invoke.test.ts
@@ -2,6 +2,8 @@ import awsLite from '@aws-lite/client'
 import {beforeEach, describe, expect, test} from 'vitest'
 import {invoke} from '../src/invoke/index.js'
 
+const context = {}
+
 beforeEach(() => awsLite.testing.reset())
 
 describe('invoke', () => {
@@ -11,12 +13,12 @@ describe('invoke', () => {
     })
     awsLite.testing.mock('SNS.Publish', {MessageId: 'm-1'})
 
-    const event = {hello: 'world'}
-    await invoke({name: 'my-fn', event})
+    const payload = {event: {hello: 'world'}, context}
+    await invoke('my-fn', payload)
 
     const {request} = awsLite.testing.getLastRequest('SNS.Publish')
     expect(request.TopicArn).toBe('arn:topic')
-    expect(request.Message).toBe(JSON.stringify(event))
+    expect(request.Message).toBe(JSON.stringify(payload))
   })
 
   test('invoke publishes to SQS queue', async () => {
@@ -25,12 +27,12 @@ describe('invoke', () => {
     })
     awsLite.testing.mock('SQS.SendMessage', {MessageId: 'm-1'})
 
-    const event = {hello: 'world'}
-    await invoke({name: 'my-fn', event})
+    const payload = {event: {hello: 'world'}, context}
+    await invoke('my-fn', payload)
 
     const {request} = awsLite.testing.getLastRequest('SQS.SendMessage')
     expect(request.QueueUrl).toBe('https://my-queue')
-    expect(request.MessageBody).toBe(JSON.stringify(event))
+    expect(request.MessageBody).toBe(JSON.stringify(payload))
     expect(request.MessageGroupId).toBe('my-fn')
   })
 
@@ -40,18 +42,18 @@ describe('invoke', () => {
     })
     awsLite.testing.mock('Lambda.Invoke', {StatusCode: 200})
 
-    const event = {hello: 'world'}
-    await invoke({name: 'my-fn', event})
+    const payload = {event: {hello: 'world'}, context}
+    await invoke('my-fn', payload)
 
     const {request} = awsLite.testing.getLastRequest('Lambda.Invoke')
     expect(request.FunctionName).toBe('arn:lambda:my-fn')
-    expect(request.Payload).toEqual({event})
+    expect(request.Payload).toEqual({payload})
   })
 
   test('invoke throws when resource envelope has no dispatchable target', async () => {
     awsLite.testing.mock('DynamoDB.GetItem', {Item: {resources: {}}})
 
-    await expect(invoke({name: 'my-fn', event: {hello: 'world'}})).rejects.toThrow('No dispatchable resource for function: my-fn')
+    await expect(invoke('my-fn', {event: {hello: 'world'}, context})).rejects.toThrow('No dispatchable resource for function: my-fn')
   })
 
   test('invoke queries DynamoDB with the expected key shape', async () => {
@@ -60,7 +62,7 @@ describe('invoke', () => {
     })
     awsLite.testing.mock('SNS.Publish', {MessageId: 'm-1'})
 
-    await invoke({name: 'my-fn', event: {}})
+    await invoke('my-fn', {event: {}, context})
 
     const {request} = awsLite.testing.getLastRequest('DynamoDB.GetItem')
     expect(request.TableName).toBe('test-disco-table')
@@ -68,19 +70,19 @@ describe('invoke', () => {
   })
 
   test('invoke throws when name is empty', async () => {
-    await expect(invoke({name: '', event: {}})).rejects.toThrow('Function name was not provided')
+    await expect(invoke('', {event: {}, context})).rejects.toThrow('Function name was not provided')
   })
 
   test('invoke throws when function is not found in disco table', async () => {
     awsLite.testing.mock('DynamoDB.GetItem', {})
 
-    await expect(invoke({name: 'missing-fn', event: {}})).rejects.toThrow('Function not found: missing-fn')
+    await expect(invoke('missing-fn', {event: {}, context})).rejects.toThrow('Function not found: missing-fn')
   })
 
   test('invoke throws when event payload exceeds 256KB', async () => {
     const event = {blob: 'a'.repeat(256 * 1024)}
 
-    await expect(invoke({name: 'my-fn', event})).rejects.toThrow('Event exceeds maximum size of 256KB')
+    await expect(invoke('my-fn', {event, context})).rejects.toThrow('Event exceeds maximum size of 256KB')
     expect(awsLite.testing.getAllRequests('DynamoDB.GetItem')).toBeUndefined()
   })
 })

--- a/test/invoke.test.ts
+++ b/test/invoke.test.ts
@@ -1,8 +1,10 @@
 import awsLite from '@aws-lite/client'
 import {beforeEach, describe, expect, test} from 'vitest'
+import type {ResourcesApi} from '../src'
 import {invoke} from '../src/invoke.js'
 
-const context = {}
+const resources = {} as ResourcesApi
+const context = {resources}
 
 beforeEach(() => awsLite.testing.reset())
 

--- a/test/invoke.test.ts
+++ b/test/invoke.test.ts
@@ -48,18 +48,20 @@ describe('invoke', () => {
         expect(request.Payload).toEqual({ event })
     })
 
-    test('invoke makes no AWS calls when resource envelope is empty', async () => {
+    test('invoke throws when resource envelope has no dispatchable target', async () => {
         awsLite.testing.mock('DynamoDB.GetItem', { Item: { resources: {} } })
 
-        await invoke({ name: 'my-fn', event: { hello: 'world' } })
+        await expect(invoke({ name: 'my-fn', event: { hello: 'world' } })).rejects.toThrow(
+            'No dispatchable resource for function: my-fn',
+        )
 
-        expect(awsLite.testing.getAllRequests('SNS.Publish')).toBeUndefined()
-        expect(awsLite.testing.getAllRequests('SQS.SendMessage')).toBeUndefined()
-        expect(awsLite.testing.getAllRequests('Lambda.Invoke')).toBeUndefined()
     })
 
     test('invoke queries DynamoDB with the expected key shape', async () => {
-        awsLite.testing.mock('DynamoDB.GetItem', { Item: { resources: {} } })
+        awsLite.testing.mock('DynamoDB.GetItem', {
+            Item: { resources: { topic: { logicalResourceId: 'foo', physicalResourceId: 'arn:topic' } } },
+        })
+        awsLite.testing.mock('SNS.Publish', { MessageId: 'm-1' })
 
         await invoke({ name: 'my-fn', event: {} })
 
@@ -70,6 +72,12 @@ describe('invoke', () => {
 
     test('invoke throws when name is empty', async () => {
         await expect(invoke({ name: '', event: {} })).rejects.toThrow('Function name was not provided')
+    })
+
+    test('invoke throws when function is not found in disco table', async () => {
+        awsLite.testing.mock('DynamoDB.GetItem', {})
+
+        await expect(invoke({ name: 'missing-fn', event: {} })).rejects.toThrow('Function not found: missing-fn')
     })
 })
 

--- a/test/invoke.test.ts
+++ b/test/invoke.test.ts
@@ -1,0 +1,75 @@
+import awsLite from '@aws-lite/client'
+import { beforeEach, describe, expect, test } from 'vitest'
+import { invoke } from '../src/invoke/index.js'
+
+beforeEach(() => awsLite.testing.reset())
+
+describe('invoke', () => {
+    test('invoke publishes to SNS topic', async () => {
+        awsLite.testing.mock('DynamoDB.GetItem', {
+            Item: { resources: { topic: { logicalResourceId: 'foo', physicalResourceId: 'arn:topic' } } },
+        })
+        awsLite.testing.mock('SNS.Publish', { MessageId: 'm-1' })
+
+        const event = { hello: 'world' }
+        await invoke({ name: 'my-fn', event })
+
+        const { request } = awsLite.testing.getLastRequest('SNS.Publish')
+        expect(request.TopicArn).toBe('arn:topic')
+        expect(request.Message).toBe(JSON.stringify(event))
+    })
+
+    test('invoke publishes to SQS queue', async () => {
+        awsLite.testing.mock('DynamoDB.GetItem', {
+            Item: { resources: { queue: { logicalResourceId: 'foo', physicalResourceId: 'https://my-queue' } } },
+        })
+        awsLite.testing.mock('SQS.SendMessage', { MessageId: 'm-1' })
+
+        const event = { hello: 'world' }
+        await invoke({ name: 'my-fn', event })
+
+        const { request } = awsLite.testing.getLastRequest('SQS.SendMessage')
+        expect(request.QueueUrl).toBe('https://my-queue')
+        expect(request.MessageBody).toBe(JSON.stringify(event))
+        expect(request.MessageGroupId).toBe('my-fn')
+    })
+
+    test('invoke calls Lambda function', async () => {
+        awsLite.testing.mock('DynamoDB.GetItem', {
+            Item: { resources: { function: { logicalResourceId: 'foo', physicalResourceId: 'arn:lambda:my-fn' } } },
+        })
+        awsLite.testing.mock('Lambda.Invoke', { StatusCode: 200 })
+
+        const event = { hello: 'world' }
+        await invoke({ name: 'my-fn', event })
+
+        const { request } = awsLite.testing.getLastRequest('Lambda.Invoke')
+        expect(request.FunctionName).toBe('arn:lambda:my-fn')
+        expect(request.Payload).toEqual({ event })
+    })
+
+    test('invoke makes no AWS calls when resource envelope is empty', async () => {
+        awsLite.testing.mock('DynamoDB.GetItem', { Item: { resources: {} } })
+
+        await invoke({ name: 'my-fn', event: { hello: 'world' } })
+
+        expect(awsLite.testing.getAllRequests('SNS.Publish')).toBeUndefined()
+        expect(awsLite.testing.getAllRequests('SQS.SendMessage')).toBeUndefined()
+        expect(awsLite.testing.getAllRequests('Lambda.Invoke')).toBeUndefined()
+    })
+
+    test('invoke queries DynamoDB with the expected key shape', async () => {
+        awsLite.testing.mock('DynamoDB.GetItem', { Item: { resources: {} } })
+
+        await invoke({ name: 'my-fn', event: {} })
+
+        const { request } = awsLite.testing.getLastRequest('DynamoDB.GetItem')
+        expect(request.TableName).toBe('test-disco-table')
+        expect(request.Key).toEqual({ PK: 'arc-app-res', SK: 'my-fn' })
+    })
+
+    test('invoke throws when name is empty', async () => {
+        await expect(invoke({ name: '', event: {} })).rejects.toThrow('Function name was not provided')
+    })
+})
+

--- a/test/invoke.test.ts
+++ b/test/invoke.test.ts
@@ -33,7 +33,6 @@ describe('invoke', () => {
     const {request} = awsLite.testing.getLastRequest('SQS.SendMessage')
     expect(request.QueueUrl).toBe('https://my-queue')
     expect(request.MessageBody).toBe(JSON.stringify(payload))
-    expect(request.MessageGroupId).toBe('my-fn')
   })
 
   test('invoke calls Lambda function', async () => {

--- a/test/invoke.test.ts
+++ b/test/invoke.test.ts
@@ -1,83 +1,86 @@
 import awsLite from '@aws-lite/client'
-import { beforeEach, describe, expect, test } from 'vitest'
-import { invoke } from '../src/invoke/index.js'
+import {beforeEach, describe, expect, test} from 'vitest'
+import {invoke} from '../src/invoke/index.js'
 
 beforeEach(() => awsLite.testing.reset())
 
 describe('invoke', () => {
-    test('invoke publishes to SNS topic', async () => {
-        awsLite.testing.mock('DynamoDB.GetItem', {
-            Item: { resources: { topic: { logicalResourceId: 'foo', physicalResourceId: 'arn:topic' } } },
-        })
-        awsLite.testing.mock('SNS.Publish', { MessageId: 'm-1' })
-
-        const event = { hello: 'world' }
-        await invoke({ name: 'my-fn', event })
-
-        const { request } = awsLite.testing.getLastRequest('SNS.Publish')
-        expect(request.TopicArn).toBe('arn:topic')
-        expect(request.Message).toBe(JSON.stringify(event))
+  test('invoke publishes to SNS topic', async () => {
+    awsLite.testing.mock('DynamoDB.GetItem', {
+      Item: {resources: {topic: {logicalResourceId: 'foo', physicalResourceId: 'arn:topic'}}},
     })
+    awsLite.testing.mock('SNS.Publish', {MessageId: 'm-1'})
 
-    test('invoke publishes to SQS queue', async () => {
-        awsLite.testing.mock('DynamoDB.GetItem', {
-            Item: { resources: { queue: { logicalResourceId: 'foo', physicalResourceId: 'https://my-queue' } } },
-        })
-        awsLite.testing.mock('SQS.SendMessage', { MessageId: 'm-1' })
+    const event = {hello: 'world'}
+    await invoke({name: 'my-fn', event})
 
-        const event = { hello: 'world' }
-        await invoke({ name: 'my-fn', event })
+    const {request} = awsLite.testing.getLastRequest('SNS.Publish')
+    expect(request.TopicArn).toBe('arn:topic')
+    expect(request.Message).toBe(JSON.stringify(event))
+  })
 
-        const { request } = awsLite.testing.getLastRequest('SQS.SendMessage')
-        expect(request.QueueUrl).toBe('https://my-queue')
-        expect(request.MessageBody).toBe(JSON.stringify(event))
-        expect(request.MessageGroupId).toBe('my-fn')
+  test('invoke publishes to SQS queue', async () => {
+    awsLite.testing.mock('DynamoDB.GetItem', {
+      Item: {resources: {queue: {logicalResourceId: 'foo', physicalResourceId: 'https://my-queue'}}},
     })
+    awsLite.testing.mock('SQS.SendMessage', {MessageId: 'm-1'})
 
-    test('invoke calls Lambda function', async () => {
-        awsLite.testing.mock('DynamoDB.GetItem', {
-            Item: { resources: { function: { logicalResourceId: 'foo', physicalResourceId: 'arn:lambda:my-fn' } } },
-        })
-        awsLite.testing.mock('Lambda.Invoke', { StatusCode: 200 })
+    const event = {hello: 'world'}
+    await invoke({name: 'my-fn', event})
 
-        const event = { hello: 'world' }
-        await invoke({ name: 'my-fn', event })
+    const {request} = awsLite.testing.getLastRequest('SQS.SendMessage')
+    expect(request.QueueUrl).toBe('https://my-queue')
+    expect(request.MessageBody).toBe(JSON.stringify(event))
+    expect(request.MessageGroupId).toBe('my-fn')
+  })
 
-        const { request } = awsLite.testing.getLastRequest('Lambda.Invoke')
-        expect(request.FunctionName).toBe('arn:lambda:my-fn')
-        expect(request.Payload).toEqual({ event })
+  test('invoke calls Lambda function', async () => {
+    awsLite.testing.mock('DynamoDB.GetItem', {
+      Item: {resources: {function: {logicalResourceId: 'foo', physicalResourceId: 'arn:lambda:my-fn'}}},
     })
+    awsLite.testing.mock('Lambda.Invoke', {StatusCode: 200})
 
-    test('invoke throws when resource envelope has no dispatchable target', async () => {
-        awsLite.testing.mock('DynamoDB.GetItem', { Item: { resources: {} } })
+    const event = {hello: 'world'}
+    await invoke({name: 'my-fn', event})
 
-        await expect(invoke({ name: 'my-fn', event: { hello: 'world' } })).rejects.toThrow(
-            'No dispatchable resource for function: my-fn',
-        )
+    const {request} = awsLite.testing.getLastRequest('Lambda.Invoke')
+    expect(request.FunctionName).toBe('arn:lambda:my-fn')
+    expect(request.Payload).toEqual({event})
+  })
 
+  test('invoke throws when resource envelope has no dispatchable target', async () => {
+    awsLite.testing.mock('DynamoDB.GetItem', {Item: {resources: {}}})
+
+    await expect(invoke({name: 'my-fn', event: {hello: 'world'}})).rejects.toThrow('No dispatchable resource for function: my-fn')
+  })
+
+  test('invoke queries DynamoDB with the expected key shape', async () => {
+    awsLite.testing.mock('DynamoDB.GetItem', {
+      Item: {resources: {topic: {logicalResourceId: 'foo', physicalResourceId: 'arn:topic'}}},
     })
+    awsLite.testing.mock('SNS.Publish', {MessageId: 'm-1'})
 
-    test('invoke queries DynamoDB with the expected key shape', async () => {
-        awsLite.testing.mock('DynamoDB.GetItem', {
-            Item: { resources: { topic: { logicalResourceId: 'foo', physicalResourceId: 'arn:topic' } } },
-        })
-        awsLite.testing.mock('SNS.Publish', { MessageId: 'm-1' })
+    await invoke({name: 'my-fn', event: {}})
 
-        await invoke({ name: 'my-fn', event: {} })
+    const {request} = awsLite.testing.getLastRequest('DynamoDB.GetItem')
+    expect(request.TableName).toBe('test-disco-table')
+    expect(request.Key).toEqual({PK: 'arc-app-res', SK: 'my-fn'})
+  })
 
-        const { request } = awsLite.testing.getLastRequest('DynamoDB.GetItem')
-        expect(request.TableName).toBe('test-disco-table')
-        expect(request.Key).toEqual({ PK: 'arc-app-res', SK: 'my-fn' })
-    })
+  test('invoke throws when name is empty', async () => {
+    await expect(invoke({name: '', event: {}})).rejects.toThrow('Function name was not provided')
+  })
 
-    test('invoke throws when name is empty', async () => {
-        await expect(invoke({ name: '', event: {} })).rejects.toThrow('Function name was not provided')
-    })
+  test('invoke throws when function is not found in disco table', async () => {
+    awsLite.testing.mock('DynamoDB.GetItem', {})
 
-    test('invoke throws when function is not found in disco table', async () => {
-        awsLite.testing.mock('DynamoDB.GetItem', {})
+    await expect(invoke({name: 'missing-fn', event: {}})).rejects.toThrow('Function not found: missing-fn')
+  })
 
-        await expect(invoke({ name: 'missing-fn', event: {} })).rejects.toThrow('Function not found: missing-fn')
-    })
+  test('invoke throws when event payload exceeds 256KB', async () => {
+    const event = {blob: 'a'.repeat(256 * 1024)}
+
+    await expect(invoke({name: 'my-fn', event})).rejects.toThrow('Event exceeds maximum size of 256KB')
+    expect(awsLite.testing.getAllRequests('DynamoDB.GetItem')).toBeUndefined()
+  })
 })
-

--- a/test/invoke.test.ts
+++ b/test/invoke.test.ts
@@ -78,6 +78,14 @@ describe('invoke', () => {
     await expect(invoke('missing-fn', {event: {data: {}}, context})).rejects.toThrow('Function not found: missing-fn')
   })
 
+  test('invoke throws when function is found but missing resource', async () => {
+    awsLite.testing.mock('DynamoDB.GetItem', {Item: {}})
+
+    await expect(invoke('missing-resource', {event: {data: {}}, context})).rejects.toThrow(
+      'Resource record for missing-resource is missing resources',
+    )
+  })
+
   test('invoke throws when event payload exceeds 256KB', async () => {
     const event = {data: {blob: 'a'.repeat(256 * 1024)}}
 

--- a/test/invoke.test.ts
+++ b/test/invoke.test.ts
@@ -13,7 +13,7 @@ describe('invoke', () => {
     })
     awsLite.testing.mock('SNS.Publish', {MessageId: 'm-1'})
 
-    const payload = {event: {hello: 'world'}, context}
+    const payload = {event: {data: {hello: 'world'}}, context}
     await invoke('my-fn', payload)
 
     const {request} = awsLite.testing.getLastRequest('SNS.Publish')
@@ -27,7 +27,7 @@ describe('invoke', () => {
     })
     awsLite.testing.mock('SQS.SendMessage', {MessageId: 'm-1'})
 
-    const payload = {event: {hello: 'world'}, context}
+    const payload = {event: {data: {hello: 'world'}}, context}
     await invoke('my-fn', payload)
 
     const {request} = awsLite.testing.getLastRequest('SQS.SendMessage')
@@ -42,7 +42,7 @@ describe('invoke', () => {
     })
     awsLite.testing.mock('Lambda.Invoke', {StatusCode: 200})
 
-    const payload = {event: {hello: 'world'}, context}
+    const payload = {event: {data: {hello: 'world'}}, context}
     await invoke('my-fn', payload)
 
     const {request} = awsLite.testing.getLastRequest('Lambda.Invoke')
@@ -53,7 +53,9 @@ describe('invoke', () => {
   test('invoke throws when resource envelope has no dispatchable target', async () => {
     awsLite.testing.mock('DynamoDB.GetItem', {Item: {resources: {}}})
 
-    await expect(invoke('my-fn', {event: {hello: 'world'}, context})).rejects.toThrow('No dispatchable resource for function: my-fn')
+    await expect(invoke('my-fn', {event: {data: {hello: 'world'}}, context})).rejects.toThrow(
+      'No dispatchable resource for function: my-fn',
+    )
   })
 
   test('invoke queries DynamoDB with the expected key shape', async () => {
@@ -62,7 +64,7 @@ describe('invoke', () => {
     })
     awsLite.testing.mock('SNS.Publish', {MessageId: 'm-1'})
 
-    await invoke('my-fn', {event: {}, context})
+    await invoke('my-fn', {event: {data: {}}, context})
 
     const {request} = awsLite.testing.getLastRequest('DynamoDB.GetItem')
     expect(request.TableName).toBe('test-disco-table')
@@ -70,17 +72,17 @@ describe('invoke', () => {
   })
 
   test('invoke throws when name is empty', async () => {
-    await expect(invoke('', {event: {}, context})).rejects.toThrow('Function name was not provided')
+    await expect(invoke('', {event: {data: {}}, context})).rejects.toThrow('Function name was not provided')
   })
 
   test('invoke throws when function is not found in disco table', async () => {
     awsLite.testing.mock('DynamoDB.GetItem', {})
 
-    await expect(invoke('missing-fn', {event: {}, context})).rejects.toThrow('Function not found: missing-fn')
+    await expect(invoke('missing-fn', {event: {data: {}}, context})).rejects.toThrow('Function not found: missing-fn')
   })
 
   test('invoke throws when event payload exceeds 256KB', async () => {
-    const event = {blob: 'a'.repeat(256 * 1024)}
+    const event = {data: {blob: 'a'.repeat(256 * 1024)}}
 
     await expect(invoke('my-fn', {event, context})).rejects.toThrow('Event exceeds maximum size of 256KB')
     expect(awsLite.testing.getAllRequests('DynamoDB.GetItem')).toBeUndefined()

--- a/test/invoke.test.ts
+++ b/test/invoke.test.ts
@@ -46,7 +46,7 @@ describe('invoke', () => {
 
     const {request} = awsLite.testing.getLastRequest('Lambda.Invoke')
     expect(request.FunctionName).toBe('arn:lambda:my-fn')
-    expect(request.Payload).toEqual({payload})
+    expect(request.Payload).toEqual(payload)
   })
 
   test('invoke throws when resource envelope has no invokeable target', async () => {

--- a/test/invoke.test.ts
+++ b/test/invoke.test.ts
@@ -1,6 +1,6 @@
 import awsLite from '@aws-lite/client'
 import {beforeEach, describe, expect, test} from 'vitest'
-import {invoke} from '../src/invoke/index.js'
+import {invoke} from '../src/invoke.js'
 
 const context = {}
 
@@ -50,12 +50,10 @@ describe('invoke', () => {
     expect(request.Payload).toEqual({payload})
   })
 
-  test('invoke throws when resource envelope has no dispatchable target', async () => {
+  test('invoke throws when resource envelope has no invokeable target', async () => {
     awsLite.testing.mock('DynamoDB.GetItem', {Item: {resources: {}}})
 
-    await expect(invoke('my-fn', {event: {data: {hello: 'world'}}, context})).rejects.toThrow(
-      'No dispatchable resource for function: my-fn',
-    )
+    await expect(invoke('my-fn', {event: {data: {hello: 'world'}}, context})).rejects.toThrow('No invokeable resource for function: my-fn')
   })
 
   test('invoke queries DynamoDB with the expected key shape', async () => {

--- a/test/invoke.test.ts
+++ b/test/invoke.test.ts
@@ -81,7 +81,7 @@ describe('invoke', () => {
   test('invoke throws when event payload exceeds 256KB', async () => {
     const event = {data: {blob: 'a'.repeat(256 * 1024)}}
 
-    await expect(invoke('my-fn', {event, context})).rejects.toThrow('Event exceeds maximum size of 256KB')
+    await expect(invoke('my-fn', {event, context})).rejects.toThrow('Payload exceeds maximum size of 256KB')
     expect(awsLite.testing.getAllRequests('DynamoDB.GetItem')).toBeUndefined()
   })
 })

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -1,7 +1,7 @@
 import process from 'node:process'
 import awsLite from '@aws-lite/client'
 
-process.env['AWS_REGION'] = 'us-east-1'
-process.env['SANITY_DISCO'] = 'test-disco-table'
+process.env.AWS_REGION = 'us-east-1'
+process.env.SANITY_DISCO = 'test-disco-table'
 
 awsLite.testing.enable()

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -1,0 +1,6 @@
+import awsLite from '@aws-lite/client'
+
+process.env.AWS_REGION = 'us-east-1'
+process.env.SANITY_DISCO = 'test-disco-table'
+
+awsLite.testing.enable()

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -1,7 +1,7 @@
 import process from 'node:process'
 import awsLite from '@aws-lite/client'
 
-process.env.AWS_REGION = 'us-east-1'
-process.env.SANITY_DISCO = 'test-disco-table'
+process.env['AWS_REGION'] = 'us-east-1'
+process.env['SANITY_DISCO'] = 'test-disco-table'
 
 awsLite.testing.enable()

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -1,6 +1,7 @@
+import process from 'node:process'
 import awsLite from '@aws-lite/client'
 
-process.env.AWS_REGION = 'us-east-1'
-process.env.SANITY_DISCO = 'test-disco-table'
+process.env['AWS_REGION'] = 'us-east-1'
+process.env['SANITY_DISCO'] = 'test-disco-table'
 
 awsLite.testing.enable()

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -35,7 +35,8 @@
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
-    "erasableSyntaxOnly": true
+    "erasableSyntaxOnly": true,
+    "types": ["node", "@aws-lite/dynamodb-types", "@aws-lite/lambda-types", "@aws-lite/sns-types", "@aws-lite/sqs-types"]
   },
   "exclude": ["node_modules", "dist"],
   "include": ["src/**/*.ts"]

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,6 +5,7 @@ export default defineConfig({
     globals: false,
     include: ['test/**/*.test.ts'],
     environment: 'node',
+    setupFiles: ['./test/setup.ts'],
 
     coverage: {
       reporter: ['text', 'json-summary', 'json'],


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

Adds an `invoke(name, payload)` helper that lets user call a Sanity function by name. The function name is resolved against the resource-discovery DynamoDB table (SANITY_DISCO) and the payload is delivered to whichever backing resource the function uses:

- SNS topic → SNS.Publish
- SQS queue → SQS.SendMessage
- Lambda function → Lambda.Invoke (async, InvocationType: 'Event')

AWS access is provided via @aws-lite/* (added as dev + peer dependencies for local dev purposes). The new lambda layer contains these dependencies so we don't need to bundle them into this package.

Things I did on purpose:
- Using the lowest common denominator, 256kb, for payload size. SNS = 256kb, SQS/Lambda `Event` 1mb, Lambda `RequestResponse` 6mb.
- No support for Lambda `RequestResponse` for now, waiting for HTTP Functions.
- Not passing a `MessageGroupId` into the SQS invoke. We will in a later version of this code when we add support for fifo queues and concurrency of 1.

See: [RUN-1433](https://linear.app/sanity/issue/RUN-1434/add-invoke-method-to-sanityfunctions)

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

- src/invoke.ts — discovery lookup, size guard, transport selection, and lazy/retryable client init.
- src/types.ts — `FunctionPayload`, `FunctionResource`, and the `FunctionResourceEnvelope` discriminated-union type.

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

Added new automated tests and manually added this code to an existing function to check it could invoke another function.