### PR TITLE
feat: add local invoke path

### DIFF
--- a/src/invoke.ts
+++ b/src/invoke.ts
@@ -57,6 +57,15 @@ export async function invoke(name: string, payload: FunctionPayload) {
     throw new Error(`Payload exceeds maximum size of ${MAX_EVENT_SIZE_BYTES / 1024}KB`)
   }
 
+  // Local invoke path for Sanity CLI
+  if (payload?.context?.local) {
+    if (!payload?.context?.invoke) {
+      throw new Error(`No local invoke handler configured for function: ${name}`)
+    }
+    await payload.context.invoke(name, payload)
+    return
+  }
+
   const aws = await getAwsLite()
   if (!aws) throw new Error(`Unable to invoke function: ${name}`)
 

--- a/src/invoke.ts
+++ b/src/invoke.ts
@@ -62,7 +62,7 @@ export async function invoke(name: string, payload: FunctionPayload) {
     if (!payload?.context?.invoke) {
       throw new Error(`No local invoke handler configured for function: ${name}`)
     }
-    await payload.context.invoke(name, payload)
+    payload.context.invoke(name, payload)
     return
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,9 @@
 /**
+ * Callback provided by Sanity CLI when doing local development
+ */
+export type InvokeCallback = (name: string, payload: FunctionPayload) => Promise<void>
+
+/**
  * The context object passed to the function handler.
  */
 export interface FunctionContext {
@@ -16,6 +21,7 @@ export interface FunctionContext {
    * Otherwise, the property is not set.
    */
   local?: boolean
+  invoke?: InvokeCallback
   /**
    * Options that can be passed to a `@sanity/client` constructor to configure it
    * against the project and dataset which triggered the event. Note that you should
@@ -50,6 +56,7 @@ export interface ScheduledFunctionContext {
    * Otherwise, the property is not set.
    */
   local?: boolean
+  invoke?: InvokeCallback
   /**
    * Options that can be passed to a `@sanity/client` constructor to configure it
    * against the project and dataset which triggered the event. Note that you should

--- a/test/invoke.test.ts
+++ b/test/invoke.test.ts
@@ -1,5 +1,5 @@
 import awsLite from '@aws-lite/client'
-import {beforeEach, describe, expect, test} from 'vitest'
+import {beforeEach, describe, expect, test, vi} from 'vitest'
 import type {ResourcesApi} from '../src'
 import {invoke} from '../src/invoke.js'
 
@@ -49,6 +49,14 @@ describe('invoke', () => {
     const {request} = awsLite.testing.getLastRequest('Lambda.Invoke')
     expect(request.FunctionName).toBe('arn:lambda:my-fn')
     expect(request.Payload).toEqual(payload)
+  })
+
+  test('invoke calls local function', async () => {
+    const localInvoke = vi.fn()
+    const payload = {event: {data: {hello: 'world'}}, context: {...context, local: true, invoke: localInvoke}}
+    await invoke('my-fn', payload)
+
+    expect(localInvoke).toHaveBeenCalledWith('my-fn', payload)
   })
 
   test('invoke throws when resource envelope has no invokeable target', async () => {


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

When running locally in the functions dev server or test command the context is populated with two additional properties.

```javascript
{
  context: {
    local: boolean,
    invoke: Function
  }
}
```

This change checks to see if local is true and if the invoke method exists. If it does it will execute the provided method.

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

The code review for this one should be pretty easy but I will follow up with everyone on Slack.

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

I've added a unit test.

To test locally, build the latest runtime-cli from main and use that to run the dev server or test commands in a project that has npm linked this branch of functions-node. Then you can use the:

```javascript
import { invoke } from '@sanity/functions'

await invoke('func-name', { context, event})
```

to test locally.