### PR TITLE
fix: generic event handler

### DIFF
--- a/src/definers.ts
+++ b/src/definers.ts
@@ -1,4 +1,4 @@
-import type {DocumentEventHandler, ScheduledEventHandler, SyncTagInvalidateEventHandler} from './types.js'
+import type {DocumentEventHandler, EventHandler, ScheduledEventHandler, SyncTagInvalidateEventHandler} from './types.js'
 
 /**
  * Defines a "document event" function handler.
@@ -32,6 +32,18 @@ export function scheduledEventHandler(handler: ScheduledEventHandler): Scheduled
  * @returns The handler function, unmodified.
  */
 export function syncTagInvalidateEventHandler(handler: SyncTagInvalidateEventHandler): SyncTagInvalidateEventHandler {
+  if (typeof handler !== 'function') throw new TypeError('`handler` must be a function')
+  return handler
+}
+
+/**
+ * Defines a "generic" function handler.
+ * Returns the handler function as-is, only providing the types and doing basic validation.
+ *
+ * @param handler - The event handler function to use.
+ * @returns The handler function, unmodified.
+ */
+export function eventHandler<IData = any>(handler: EventHandler<IData>): EventHandler<IData> {
   if (typeof handler !== 'function') throw new TypeError('`handler` must be a function')
   return handler
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -118,6 +118,31 @@ export type DocumentEventHandler<IData = any> = (envelope: {context: FunctionCon
 export type ScheduledEventHandler = (envelope: {context: ScheduledFunctionContext}) => void | Promise<void>
 
 /**
+ * A generic function context type which supports all function types
+ */
+export type GenericContext = FunctionContext | ScheduledFunctionContext | SyncTagInvalidateContext
+
+/**
+ * A generic function event type which supports all function types
+ */
+export type GenericEvent = DocumentEvent | SyncTagInvalidateEvent
+
+/**
+ * A generic function handler that can receive the payload of any function type.
+ *
+ * The envelope is a discriminated union of every supported payload shape, so a
+ * single handler can be registered regardless of the event source. Narrow on the
+ * presence of `event`/`done` (or the shape of `context`) to access the fields
+ * specific to each event type.
+ */
+export type EventHandler<IData = any> = (
+  envelope:
+    | {context: FunctionContext; event: DocumentEvent<IData>}
+    | {context: ScheduledFunctionContext}
+    | {context: SyncTagInvalidateContext; event: SyncTagInvalidateEvent; done: SyncTagInvalidateCallback},
+) => void | Promise<void>
+
+/**
  * A callback function to invoke once a sync-tag-invalidate event has been processed. Signals to Sanity that sync tag invalidation has completed.
  */
 export type SyncTagInvalidateCallback = (syncTags: string[]) => Promise<Response>
@@ -180,8 +205,8 @@ export interface ResourcesApi {
  * The payload for the `invoke` method
  */
 export type FunctionPayload = {
-  event: DocumentEvent
-  context: FunctionContext | ScheduledFunctionContext | SyncTagInvalidateContext
+  event: GenericEvent
+  context: GenericContext
 }
 
 /**

--- a/test/definers.test-d.ts
+++ b/test/definers.test-d.ts
@@ -1,9 +1,11 @@
-import {assertType, describe, expect, expectTypeOf, test} from 'vitest'
+import { assertType, describe, expect, expectTypeOf, test } from 'vitest'
 import {
   type BlueprintResource,
   type DocumentEvent,
   type DocumentEventHandler,
   documentEventHandler,
+  type EventHandler,
+  eventHandler,
   type FunctionContext,
   type ResourcesApi,
   type ScheduledEventHandler,
@@ -34,20 +36,35 @@ const mockResourcesApi = (resources: BlueprintResource[] = []): ResourcesApi => 
   }) as unknown as ResourcesApi
 }
 
+const documentContext: FunctionContext = {
+  eventResourceId: 'abc123.xyz789',
+  eventResourceType: 'dataset',
+  functionResourceId: 'abc123',
+  functionResourceType: 'project',
+  clientOptions: { projectId: 'abc123', dataset: 'xyz789', token: 'sk_some-token' },
+  resources: mockResourcesApi(),
+}
+
+const scheduledContext: ScheduledFunctionContext = {
+  local: true,
+  resources: mockResourcesApi(),
+}
+
+const syncTagContext: SyncTagInvalidateContext = {
+  callbackToken: 'supersecret',
+  eventResourceId: 'abc123.xyz789',
+  eventResourceType: 'dataset',
+  functionResourceId: 'abc123',
+  functionResourceType: 'project',
+  clientOptions: { apiHost: 'api.sanity.io', projectId: 'abc123', dataset: 'xyz789' },
+  resources: mockResourcesApi(),
+}
+
+const documentEvent: DocumentEvent = { data: { _id: 'docId', _type: 'docType' } }
+const syncTagEvent: SyncTagInvalidateEvent = { data: { syncTags: ['abc:123', 'def:456'] } }
+const done: SyncTagInvalidateCallback = async (_syncTags) => new Response()
+
 describe('documentEventHandler', () => {
-  const context: FunctionContext = {
-    eventResourceId: 'abc123.xyz789',
-    eventResourceType: 'dataset',
-    functionResourceId: 'abc123',
-    functionResourceType: 'project',
-    clientOptions: {projectId: 'abc123', dataset: 'xyz789', token: 'sk_some-token'},
-    resources: mockResourcesApi(),
-  }
-
-  const event: DocumentEvent = {
-    data: {_id: 'docId', _type: 'docType'},
-  }
-
   test('has correct type signature', () => {
     expectTypeOf(documentEventHandler).toBeFunction()
     expectTypeOf(documentEventHandler).parameter(0).toExtend<DocumentEventHandler>()
@@ -61,21 +78,21 @@ describe('documentEventHandler', () => {
     const handler = documentEventHandler((envelope) => {
       expectTypeOf(envelope.context).toEqualTypeOf<FunctionContext>()
       expectTypeOf(envelope.event).toEqualTypeOf<DocumentEvent>()
-      expect(envelope.context).toEqual(context)
+      expect(envelope.context).toEqual(documentContext)
       expect(envelope.event).toEqual(event)
       expectTypeOf(envelope.event.data).toBeAny()
     })
 
-    handler({context, event})
+    handler({ context: documentContext, event: documentEvent })
   })
 
   test('can pass data type as generic', () => {
-    const handler = documentEventHandler<{foo: string}>((envelope) => {
-      expectTypeOf(envelope.event.data).toEqualTypeOf<{foo: string}>()
+    const handler = documentEventHandler<{ foo: string }>((envelope) => {
+      expectTypeOf(envelope.event.data).toEqualTypeOf<{ foo: string }>()
       expect(envelope.event.data.foo).toBe('bar')
     })
 
-    handler({context, event: {data: {foo: 'bar'}}})
+    handler({ context: documentContext, event: { data: { foo: 'bar' } } })
 
     const unknownHandler = documentEventHandler<unknown>((envelope) => {
       expectTypeOf(envelope.event.data).toEqualTypeOf<unknown>()
@@ -84,16 +101,11 @@ describe('documentEventHandler', () => {
       expect(envelope.event.data.foo).toBe('bar')
     })
 
-    unknownHandler({context, event})
+    unknownHandler({ context: documentContext, event: documentEvent })
   })
 })
 
 describe('scheduledEventHandler', () => {
-  const context: ScheduledFunctionContext = {
-    local: true,
-    resources: mockResourcesApi(),
-  }
-
   test('has correct type signature', () => {
     expectTypeOf(scheduledEventHandler).toBeFunction()
     expectTypeOf(scheduledEventHandler).parameter(0).toExtend<ScheduledEventHandler>()
@@ -106,10 +118,10 @@ describe('scheduledEventHandler', () => {
   test('handler envelope has correct types', () => {
     const handler = scheduledEventHandler((envelope) => {
       expectTypeOf(envelope.context).toEqualTypeOf<ScheduledFunctionContext>()
-      expect(envelope.context).toEqual(context)
+      expect(envelope.context).toEqual(scheduledContext)
     })
 
-    handler({context})
+    handler({ context: scheduledContext })
   })
 
   test('runs a handler', async () => {
@@ -117,27 +129,11 @@ describe('scheduledEventHandler', () => {
       return Promise.resolve()
     }
 
-    await expect(handler({context})).resolves.toBeUndefined()
+    await expect(handler({ context: scheduledContext })).resolves.toBeUndefined()
   })
 })
 
 describe('syncTagInvalidateEventHandler', () => {
-  const context: SyncTagInvalidateContext = {
-    callbackToken: 'supersecret',
-    eventResourceId: 'abc123.xyz789',
-    eventResourceType: 'dataset',
-    functionResourceId: 'abc123',
-    functionResourceType: 'project',
-    clientOptions: {apiHost: 'api.sanity.io', projectId: 'abc123', dataset: 'xyz789'},
-    resources: mockResourcesApi(),
-  }
-
-  const event: SyncTagInvalidateEvent = {
-    data: {syncTags: ['abc:123', 'def:456']},
-  }
-
-  const done: SyncTagInvalidateCallback = async (_syncTags) => new Response()
-
   test('has correct type signature', () => {
     expectTypeOf(syncTagInvalidateEventHandler).toBeFunction()
     expectTypeOf(syncTagInvalidateEventHandler).parameter(0).toExtend<SyncTagInvalidateEventHandler>()
@@ -152,11 +148,59 @@ describe('syncTagInvalidateEventHandler', () => {
       expectTypeOf(envelope.context).toEqualTypeOf<SyncTagInvalidateContext>()
       expectTypeOf(envelope.event).toEqualTypeOf<SyncTagInvalidateEvent>()
       expectTypeOf(envelope.done).toEqualTypeOf<SyncTagInvalidateCallback>()
-      expect(envelope.context).toEqual(context)
-      expect(envelope.event).toEqual(event)
+      expect(envelope.context).toEqual(syncTagContext)
+      expect(envelope.event).toEqual(syncTagEvent)
       expectTypeOf(envelope.event.data.syncTags).toBeArray()
     })
 
-    handler({context, done, event})
+    handler({ context: syncTagContext, done, event: syncTagEvent })
+  })
+})
+
+describe('eventHandler', () => {
+  test('has correct type signature', () => {
+    expectTypeOf(eventHandler).toBeFunction()
+    expectTypeOf(eventHandler).parameter(0).toExtend<EventHandler>()
+    expectTypeOf(eventHandler).returns.toExtend<EventHandler>()
+
+    // @ts-expect-error should be a function
+    assertType(eventHandler('foo'))
+  })
+
+  test('accepts and narrows every payload variant', () => {
+    const handler = eventHandler((envelope) => {
+      if ('done' in envelope) {
+        // sync-tag-invalidate payload
+        expectTypeOf(envelope.context).toEqualTypeOf<SyncTagInvalidateContext>()
+        expectTypeOf(envelope.event).toEqualTypeOf<SyncTagInvalidateEvent>()
+        expectTypeOf(envelope.done).toEqualTypeOf<SyncTagInvalidateCallback>()
+        expectTypeOf(envelope.event.data.syncTags).toBeArray()
+      } else if ('event' in envelope) {
+        // document payload
+        expectTypeOf(envelope.context).toEqualTypeOf<FunctionContext>()
+        expectTypeOf(envelope.event).toEqualTypeOf<DocumentEvent>()
+        expectTypeOf(envelope.event.data).toBeAny()
+      } else {
+        // scheduled payload
+        expectTypeOf(envelope.context).toEqualTypeOf<ScheduledFunctionContext>()
+        // @ts-expect-error scheduled payloads have no event
+        assertType(envelope.event)
+      }
+    })
+
+    handler({ context: documentContext, event: documentEvent })
+    handler({ context: scheduledContext })
+    handler({ context: syncTagContext, event: syncTagEvent, done })
+  })
+
+  test('can pass data type as generic for the document payload', () => {
+    const handler = eventHandler<{ foo: string }>((envelope) => {
+      if ('event' in envelope && !('done' in envelope)) {
+        expectTypeOf(envelope.event.data).toEqualTypeOf<{ foo: string }>()
+        expect(envelope.event.data.foo).toBe('bar')
+      }
+    })
+
+    handler({ context: documentContext, event: { data: { foo: 'bar' } } })
   })
 })

--- a/test/definers.test-d.ts
+++ b/test/definers.test-d.ts
@@ -1,4 +1,4 @@
-import { assertType, describe, expect, expectTypeOf, test } from 'vitest'
+import {assertType, describe, expect, expectTypeOf, test} from 'vitest'
 import {
   type BlueprintResource,
   type DocumentEvent,
@@ -41,7 +41,7 @@ const documentContext: FunctionContext = {
   eventResourceType: 'dataset',
   functionResourceId: 'abc123',
   functionResourceType: 'project',
-  clientOptions: { projectId: 'abc123', dataset: 'xyz789', token: 'sk_some-token' },
+  clientOptions: {projectId: 'abc123', dataset: 'xyz789', token: 'sk_some-token'},
   resources: mockResourcesApi(),
 }
 
@@ -56,12 +56,12 @@ const syncTagContext: SyncTagInvalidateContext = {
   eventResourceType: 'dataset',
   functionResourceId: 'abc123',
   functionResourceType: 'project',
-  clientOptions: { apiHost: 'api.sanity.io', projectId: 'abc123', dataset: 'xyz789' },
+  clientOptions: {apiHost: 'api.sanity.io', projectId: 'abc123', dataset: 'xyz789'},
   resources: mockResourcesApi(),
 }
 
-const documentEvent: DocumentEvent = { data: { _id: 'docId', _type: 'docType' } }
-const syncTagEvent: SyncTagInvalidateEvent = { data: { syncTags: ['abc:123', 'def:456'] } }
+const documentEvent: DocumentEvent = {data: {_id: 'docId', _type: 'docType'}}
+const syncTagEvent: SyncTagInvalidateEvent = {data: {syncTags: ['abc:123', 'def:456']}}
 const done: SyncTagInvalidateCallback = async (_syncTags) => new Response()
 
 describe('documentEventHandler', () => {
@@ -79,20 +79,20 @@ describe('documentEventHandler', () => {
       expectTypeOf(envelope.context).toEqualTypeOf<FunctionContext>()
       expectTypeOf(envelope.event).toEqualTypeOf<DocumentEvent>()
       expect(envelope.context).toEqual(documentContext)
-      expect(envelope.event).toEqual(event)
+      expect(envelope.event).toEqual(documentEvent)
       expectTypeOf(envelope.event.data).toBeAny()
     })
 
-    handler({ context: documentContext, event: documentEvent })
+    handler({context: documentContext, event: documentEvent})
   })
 
   test('can pass data type as generic', () => {
-    const handler = documentEventHandler<{ foo: string }>((envelope) => {
-      expectTypeOf(envelope.event.data).toEqualTypeOf<{ foo: string }>()
+    const handler = documentEventHandler<{foo: string}>((envelope) => {
+      expectTypeOf(envelope.event.data).toEqualTypeOf<{foo: string}>()
       expect(envelope.event.data.foo).toBe('bar')
     })
 
-    handler({ context: documentContext, event: { data: { foo: 'bar' } } })
+    handler({context: documentContext, event: {data: {foo: 'bar'}}})
 
     const unknownHandler = documentEventHandler<unknown>((envelope) => {
       expectTypeOf(envelope.event.data).toEqualTypeOf<unknown>()
@@ -101,7 +101,7 @@ describe('documentEventHandler', () => {
       expect(envelope.event.data.foo).toBe('bar')
     })
 
-    unknownHandler({ context: documentContext, event: documentEvent })
+    unknownHandler({context: documentContext, event: documentEvent})
   })
 })
 
@@ -121,7 +121,7 @@ describe('scheduledEventHandler', () => {
       expect(envelope.context).toEqual(scheduledContext)
     })
 
-    handler({ context: scheduledContext })
+    handler({context: scheduledContext})
   })
 
   test('runs a handler', async () => {
@@ -129,7 +129,7 @@ describe('scheduledEventHandler', () => {
       return Promise.resolve()
     }
 
-    await expect(handler({ context: scheduledContext })).resolves.toBeUndefined()
+    await expect(handler({context: scheduledContext})).resolves.toBeUndefined()
   })
 })
 
@@ -153,7 +153,7 @@ describe('syncTagInvalidateEventHandler', () => {
       expectTypeOf(envelope.event.data.syncTags).toBeArray()
     })
 
-    handler({ context: syncTagContext, done, event: syncTagEvent })
+    handler({context: syncTagContext, done, event: syncTagEvent})
   })
 })
 
@@ -188,19 +188,19 @@ describe('eventHandler', () => {
       }
     })
 
-    handler({ context: documentContext, event: documentEvent })
-    handler({ context: scheduledContext })
-    handler({ context: syncTagContext, event: syncTagEvent, done })
+    handler({context: documentContext, event: documentEvent})
+    handler({context: scheduledContext})
+    handler({context: syncTagContext, event: syncTagEvent, done})
   })
 
   test('can pass data type as generic for the document payload', () => {
-    const handler = eventHandler<{ foo: string }>((envelope) => {
+    const handler = eventHandler<{foo: string}>((envelope) => {
       if ('event' in envelope && !('done' in envelope)) {
-        expectTypeOf(envelope.event.data).toEqualTypeOf<{ foo: string }>()
+        expectTypeOf(envelope.event.data).toEqualTypeOf<{foo: string}>()
         expect(envelope.event.data.foo).toBe('bar')
       }
     })
 
-    handler({ context: documentContext, event: { data: { foo: 'bar' } } })
+    handler({context: documentContext, event: {data: {foo: 'bar'}}})
   })
 })

--- a/test/definers.test.ts
+++ b/test/definers.test.ts
@@ -2,6 +2,8 @@ import {describe, expect, test} from 'vitest'
 import {
   type DocumentEventHandler,
   documentEventHandler,
+  type EventHandler,
+  eventHandler,
   type ScheduledEventHandler,
   type SyncTagInvalidateEventHandler,
   scheduledEventHandler,
@@ -58,6 +60,24 @@ describe('syncTagEventHandler', () => {
     expect(() => {
       // @ts-expect-error Intentionally wrong type
       syncTagInvalidateEventHandler('foo')
+    }).toThrowErrorMatchingInlineSnapshot(`[TypeError: \`handler\` must be a function]`)
+  })
+})
+
+describe('eventHandler', () => {
+  test('passes through handler function verbatim', () => {
+    const handler = (() => {
+      console.log('Event received:')
+    }) satisfies EventHandler
+
+    const result = eventHandler(handler)
+    expect(result).toBe(handler)
+  })
+
+  test('throws error if handler is not a function', () => {
+    expect(() => {
+      // @ts-expect-error Intentionally wrong type
+      eventHandler('foo')
     }).toThrowErrorMatchingInlineSnapshot(`[TypeError: \`handler\` must be a function]`)
   })
 })


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

Adding a generic `eventHandler` so that users can invoke any type of function from the `invoke` method as well as using `defineEventFunction` in your blueprint and have it use the `eventHander` helper.

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

I hope my types make sense.

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

New unit tests added