### PR TITLE
fix: Moar generic EventHandler

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -130,17 +130,16 @@ export type GenericEvent = DocumentEvent | SyncTagInvalidateEvent
 /**
  * A generic function handler that can receive the payload of any function type.
  *
- * The envelope is a discriminated union of every supported payload shape, so a
- * single handler can be registered regardless of the event source. Narrow on the
- * presence of `event`/`done` (or the shape of `context`) to access the fields
- * specific to each event type.
+ * The envelope is intentionally permissive so a single handler can be registered
+ * regardless of the event source without narrowing: `context` is any supported
+ * context, `event` is any supported event, and `done` is optional (present only
+ * for sync-tag-invalidate events).
  */
-export type EventHandler<IData = any> = (
-  envelope:
-    | {context: FunctionContext; event: DocumentEvent<IData>}
-    | {context: ScheduledFunctionContext}
-    | {context: SyncTagInvalidateContext; event: SyncTagInvalidateEvent; done: SyncTagInvalidateCallback},
-) => void | Promise<void>
+export type EventHandler<IData = any> = (envelope: {
+  context: GenericContext
+  event: DocumentEvent<IData> | SyncTagInvalidateEvent
+  done?: SyncTagInvalidateCallback
+}) => void | Promise<void>
 
 /**
  * A callback function to invoke once a sync-tag-invalidate event has been processed. Signals to Sanity that sync tag invalidation has completed.

--- a/test/definers.test-d.ts
+++ b/test/definers.test-d.ts
@@ -7,6 +7,7 @@ import {
   type EventHandler,
   eventHandler,
   type FunctionContext,
+  type GenericContext,
   type ResourcesApi,
   type ScheduledEventHandler,
   type ScheduledFunctionContext,
@@ -167,38 +168,23 @@ describe('eventHandler', () => {
     assertType(eventHandler('foo'))
   })
 
-  test('accepts and narrows every payload variant', () => {
+  test('has a permissive envelope that needs no narrowing', () => {
     const handler = eventHandler((envelope) => {
-      if ('done' in envelope) {
-        // sync-tag-invalidate payload
-        expectTypeOf(envelope.context).toEqualTypeOf<SyncTagInvalidateContext>()
-        expectTypeOf(envelope.event).toEqualTypeOf<SyncTagInvalidateEvent>()
-        expectTypeOf(envelope.done).toEqualTypeOf<SyncTagInvalidateCallback>()
-        expectTypeOf(envelope.event.data.syncTags).toBeArray()
-      } else if ('event' in envelope) {
-        // document payload
-        expectTypeOf(envelope.context).toEqualTypeOf<FunctionContext>()
-        expectTypeOf(envelope.event).toEqualTypeOf<DocumentEvent>()
-        expectTypeOf(envelope.event.data).toBeAny()
-      } else {
-        // scheduled payload
-        expectTypeOf(envelope.context).toEqualTypeOf<ScheduledFunctionContext>()
-        // @ts-expect-error scheduled payloads have no event
-        assertType(envelope.event)
-      }
+      // `context`/`event` accept any supported shape, `done` is optional
+      expectTypeOf(envelope.context).toEqualTypeOf<GenericContext>()
+      expectTypeOf(envelope.event).toEqualTypeOf<DocumentEvent | SyncTagInvalidateEvent>()
+      expectTypeOf(envelope.done).toEqualTypeOf<SyncTagInvalidateCallback | undefined>()
+      // event data is `any` by default, so it can be accessed without a guard
+      expectTypeOf(envelope.event.data).toBeAny()
     })
 
     handler({context: documentContext, event: documentEvent})
-    handler({context: scheduledContext})
     handler({context: syncTagContext, event: syncTagEvent, done})
   })
 
   test('can pass data type as generic for the document payload', () => {
     const handler = eventHandler<{foo: string}>((envelope) => {
-      if ('event' in envelope && !('done' in envelope)) {
-        expectTypeOf(envelope.event.data).toEqualTypeOf<{foo: string}>()
-        expect(envelope.event.data.foo).toBe('bar')
-      }
+      expectTypeOf(envelope.event).toEqualTypeOf<DocumentEvent<{foo: string}> | SyncTagInvalidateEvent>()
     })
 
     handler({context: documentContext, event: {data: {foo: 'bar'}}})


### PR DESCRIPTION
### Description

<!--
What changes are introduced?
Why are these changes introduced?
What issue(s) does this solve? (with link, if possible)
-->

Okay, my previous PR looked good in theory but didn't work in practice. If you wrote the code:

```javascript
export const handler = eventHandler(async ({ context, event }) => {
})
```

You would get the TypeScript complaint:

```
Translation
    Property 'event' does not exist on type '{ context: ScheduledFunctionContext; } | { context: SyncTagInvalidateContext; event: SyncTagInvalidateEvent; done: SyncTagInvalidateCallback; } | { ...; }'.
```

So just because the scheduled function event handler doesn't have an event property it would complain.

### What to review

<!--
What steps should the reviewer take in order to review?
What parts/flows of the application/packages/tooling is affected?
-->

Does making the `EventHander` type accept a wider context and event properties make sense or should we give the schedule event handler an `event` property that is always undefined?

### Testing

<!--
Did you add sufficient testing for this change?
If not, please explain how you tested this change and why it was not
possible/practical for writing an automated test
-->

Unit tests updated
